### PR TITLE
Fix login and module issues

### DIFF
--- a/src/main/docker/cpt4_5/cpt.bat
+++ b/src/main/docker/cpt4_5/cpt.bat
@@ -1,2 +1,22 @@
 @echo off
-java -Dumls-user=xxx -Dumls-password=xxx -jar cpt4.jar 5
+rem Argument counting code from http://www.testdeveloper.com/2010/09/26/how-to-count-arguments-to-a-dos-batch-file-without-using-your-fingers-and-toes
+set _exitStatus=0
+set _argcActual=0
+set _argcExpected=2
+for %%i in (%*) do set /A _argcActual+=1
+if %_argcActual% NEQ %_argcExpected% ( 
+  call :_ShowUsage %0%, "Need to include login name and password for UMLS Terminology Services."  
+  set _exitStatus=1  
+  goto:_EOF
+)
+java -Dumls-user=%1 -Dumls-password=%2 --add-modules=java.xml.ws  -jar cpt4.jar 5
+goto:_EOF
+:_ShowUsage  
+echo [USAGE]: %~1 login password 
+if NOT "%~2" == "" (   
+  echo %~2      
+)  
+goto:eof
+:_EOF
+echo The exit status is %_exitStatus%
+cmd /c exit %_exitStatus%


### PR DESCRIPTION
This patch fixes two problems:

1. Closes #27 CPT jar error by including `--add-modules=java.xml.ws` in the command.
2. Allows user to put password and login for UMLS on command line instead of having to edit the batch file. Also provides a useful message if user forgets to do so.