### PR TITLE
Fix: UMLS login page URL

### DIFF
--- a/properties/dev/application.properties
+++ b/properties/dev/application.properties
@@ -79,7 +79,7 @@ cpt4.dir.v5=/opt/athena/addons/cpt4_5
 
 vocabularies.download.control.files.url=https://github.com/OHDSI/CommonDataModel
 vocabularies.download.forum.url=http://forums.ohdsi.org/c/implementers
-vocabularies.download.umls.url=https://utslogin.nlm.nih.gov/cas/login
+vocabularies.download.umls.url=https://uts.nlm.nih.gov/uts/login
 
 cas.defaultIDP=https://localhost:8443/cas/idp
 cas.entityId=com:odysseusinc:athena:sp

--- a/properties/prod/application.properties
+++ b/properties/prod/application.properties
@@ -73,7 +73,7 @@ cpt4.dir.v5=/opt/athena/addons/cpt4_5
 
 vocabularies.download.control.files.url=https://github.com/OHDSI/CommonDataModel
 vocabularies.download.forum.url=http://forums.ohdsi.org/c/implementers
-vocabularies.download.umls.url=https://utslogin.nlm.nih.gov/cas/login
+vocabularies.download.umls.url=https://uts.nlm.nih.gov/uts/login
 
 cas.defaultIDP=https://cas.odysseusinc.com/cas/idp
 cas.entityId=com:odysseusinc:athena:sp

--- a/properties/qa/application.properties
+++ b/properties/qa/application.properties
@@ -73,7 +73,7 @@ cpt4.dir.v5=/opt/athena/addons/cpt4_5
 
 vocabularies.download.control.files.url=https://github.com/OHDSI/CommonDataModel
 vocabularies.download.forum.url=http://forums.ohdsi.org/c/implementers
-vocabularies.download.umls.url=https://utslogin.nlm.nih.gov/cas/login
+vocabularies.download.umls.url=https://uts.nlm.nih.gov/uts/login
 
 cas.defaultIDP=https://qacas.odysseusinc.com/cas/idp
 cas.entityId=com:odysseusinc:athena:sp

--- a/properties/test/application.properties
+++ b/properties/test/application.properties
@@ -74,7 +74,7 @@ cpt4.dir.v5=/opt/athena/addons/cpt4_5
 
 vocabularies.download.control.files.url=https://github.com/OHDSI/CommonDataModel
 vocabularies.download.forum.url=http://forums.ohdsi.org/c/implementers
-vocabularies.download.umls.url=https://utslogin.nlm.nih.gov/cas/login
+vocabularies.download.umls.url=https://uts.nlm.nih.gov/uts/login
 
 cas.defaultIDP=https://athenatest.odysseusinc.com:8443/cas/idp
 cas.entityId=com:odysseusinc:athena:sp

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -85,7 +85,7 @@ cpt4.dir.v5=/opt/athena/addons/cpt4_5
 
 vocabularies.download.control.files.url=https://github.com/OHDSI/CommonDataModel
 vocabularies.download.forum.url=http://forums.ohdsi.org/c/implementers
-vocabularies.download.umls.url=https://utslogin.nlm.nih.gov/cas/login
+vocabularies.download.umls.url=https://uts.nlm.nih.gov/uts/login
 
 cas.defaultIDP=https://odysseusovh03.odysseusinc.com:8443/cas/idp
 cas.entityId=com:odysseusinc:athena:sp


### PR DESCRIPTION
A tiny fix for the issue raised on the forum: https://forums.ohdsi.org/t/how-to-run-cpt4-jar-on-athena-download-using-new-umls-login/12471/7.