### PR TITLE
fix(security): Upgrade pac4j to 4.5.9 for CVE-2026-29000

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <opensaml.version>2.6.6-patched</opensaml.version>
         <solr.version>8.11.2</solr.version>
         <spring-security-pac4j.version>4.1.0</spring-security-pac4j.version>
-        <pac4j.version>3.3.0</pac4j.version>
+        <pac4j.version>4.5.9</pac4j.version>
         <opencsv.version>3.9</opencsv.version>
         <jakarta.mail.version>1.6.7</jakarta.mail.version>
         <dockerImagePrefix>hub.odysseusinc.com</dockerImagePrefix>

--- a/src/main/java/com/odysseusinc/athena/config/CustomLogoutLogic.java
+++ b/src/main/java/com/odysseusinc/athena/config/CustomLogoutLogic.java
@@ -33,7 +33,7 @@ import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.HttpConstants;
-import org.pac4j.core.context.Pac4jConstants;
+import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.engine.DefaultLogoutLogic;


### PR DESCRIPTION
## Summary
Upgrades pac4j dependency from 3.3.0 to 4.5.9 to address **CVE-2026-29000** (CVSS 9.1 CRITICAL) - an authentication bypass vulnerability in pac4j-jwt.

## Vulnerability Details
- **CVE ID**: CVE-2026-29000
- **CVSS Score**: 9.1 (Critical)
- **Impact**: Authentication bypass in JWT validation
- **Affected Versions**: pac4j < 4.5.9, < 5.7.5, < 6.0.4
- **Fixed In**: 4.5.9 (v4.x branch), 5.7.5 (v5.x branch), 6.0.4 (v6.x branch)

## Changes Made
1. **Upgraded pac4j version** from 3.3.0 → 4.5.9 in `pom.xml`
2. **Updated import path** for `Pac4jConstants` in `CustomLogoutLogic.java`:
   - Changed: `org.pac4j.core.context.Pac4jConstants`
   - To: `org.pac4j.core.util.Pac4jConstants`
   - This is a required API change when upgrading from pac4j v3 to v4

## Testing Recommendations
- Verify JWT authentication flows still function correctly
- Test SAML authentication (used in central logout logic)
- Validate session management and logout functionality
- Check API token authentication with `ApiTokenAuthClient`

## Security Context
As a healthcare platform managing OHDSI vocabularies and terminology databases, ensuring authentication integrity is critical. This vulnerability could allow unauthorized access to sensitive medical data infrastructure.

## Related Work
- Related PR in OHDSI/WebAPI: #2496

🔒 **Please prioritize review and merge of this security fix.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)