### PR TITLE
add concept_metadata, concept_relationship_metadata and pack_content …

### DIFF
--- a/src/main/java/com/odysseusinc/athena/service/saver/v5/ConceptMetadataV5Saver.java
+++ b/src/main/java/com/odysseusinc/athena/service/saver/v5/ConceptMetadataV5Saver.java
@@ -1,0 +1,48 @@
+/*
+ *
+ * Copyright 2026 Odysseus Data Services, Inc. (EPAM Systems company)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Company: Odysseus Data Services, Inc.
+ * Created: August 14, 2026
+ *
+ */
+
+package com.odysseusinc.athena.service.saver.v5;
+
+import com.odysseusinc.athena.service.saver.CSVSaver;
+import com.odysseusinc.athena.service.saver.SaverV5;
+import org.springframework.stereotype.Service;
+
+/**
+ * CDM 5.5 only, so V5 rather than {@code common}. The vocabulary filter mirrors
+ * {@code ConceptSynonymSaver}: a metadata row is included exactly when the concept it
+ * annotates is, otherwise it dangles against the CONCEPT.csv in the same archive.
+ */
+@Service
+public class ConceptMetadataV5Saver extends CSVSaver implements SaverV5 {
+
+    @Override
+    public String fileName() {
+
+        return "CONCEPT_METADATA.csv";
+    }
+
+    @Override
+    protected String query() {
+
+        return "SELECT cm.* FROM concept_metadata cm WHERE EXISTS "
+                + "(SELECT 1 FROM CONCEPT c "
+                + "WHERE cm.CONCEPT_ID = c.CONCEPT_ID AND c.VOCABULARY_ID IN (?))";
+    }
+}

--- a/src/main/java/com/odysseusinc/athena/service/saver/v5/ConceptRelationshipMetadataV5Saver.java
+++ b/src/main/java/com/odysseusinc/athena/service/saver/v5/ConceptRelationshipMetadataV5Saver.java
@@ -1,0 +1,48 @@
+/*
+ *
+ * Copyright 2026 Odysseus Data Services, Inc. (EPAM Systems company)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Company: Odysseus Data Services, Inc.
+ * Created: August 14, 2026
+ *
+ */
+
+package com.odysseusinc.athena.service.saver.v5;
+
+import com.odysseusinc.athena.service.saver.CSVSaver;
+import com.odysseusinc.athena.service.saver.SaverV5;
+import org.springframework.stereotype.Service;
+
+/**
+ * Both concepts must be in the selection, exactly as {@code ConceptRelationshipSaver}
+ * requires — this file annotates that one, and a row here without its counterpart there
+ * violates the foreign key the upstream DDL declares.
+ */
+@Service
+public class ConceptRelationshipMetadataV5Saver extends CSVSaver implements SaverV5 {
+
+    @Override
+    public String fileName() {
+
+        return "CONCEPT_RELATIONSHIP_METADATA.csv";
+    }
+
+    @Override
+    protected String query() {
+
+        return "SELECT crm.* FROM concept_relationship_metadata crm WHERE EXISTS "
+                + "(SELECT 1 FROM CONCEPT WHERE CONCEPT_ID = crm.CONCEPT_ID_1 AND VOCABULARY_ID IN (?)) "
+                + "AND EXISTS (SELECT 1 FROM CONCEPT WHERE CONCEPT_ID = crm.CONCEPT_ID_2 AND VOCABULARY_ID IN (?))";
+    }
+}

--- a/src/main/java/com/odysseusinc/athena/service/saver/v5/PackContentV5Saver.java
+++ b/src/main/java/com/odysseusinc/athena/service/saver/v5/PackContentV5Saver.java
@@ -1,0 +1,47 @@
+/*
+ *
+ * Copyright 2026 Odysseus Data Services, Inc. (EPAM Systems company)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Company: Odysseus Data Services, Inc.
+ * Created: August 14, 2026
+ *
+ */
+
+package com.odysseusinc.athena.service.saver.v5;
+
+import com.odysseusinc.athena.service.saver.CSVSaver;
+import com.odysseusinc.athena.service.saver.SaverV5;
+import org.springframework.stereotype.Service;
+
+/**
+ * Filtered on the pack, the way {@code DrugStrengthSaver} filters on the drug — the pack
+ * is what the row is about, and the contained drug follows it into the archive.
+ */
+@Service
+public class PackContentV5Saver extends CSVSaver implements SaverV5 {
+
+    @Override
+    public String fileName() {
+
+        return "PACK_CONTENT.csv";
+    }
+
+    @Override
+    protected String query() {
+
+        return "SELECT pack_content.* "
+                + " FROM pack_content INNER JOIN CONCEPT ON PACK_CONCEPT_ID = CONCEPT_ID"
+                + " WHERE VOCABULARY_ID IN (?)";
+    }
+}

--- a/src/main/java/com/odysseusinc/athena/service/saver/v5/history/delta/ConceptMetadataDeltaSaver.java
+++ b/src/main/java/com/odysseusinc/athena/service/saver/v5/history/delta/ConceptMetadataDeltaSaver.java
@@ -1,0 +1,41 @@
+/*
+ *
+ * Copyright 2026 Odysseus Data Services, Inc. (EPAM Systems company)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Company: Odysseus Data Services, Inc.
+ * Created: August 14, 2026
+ *
+ */
+
+package com.odysseusinc.athena.service.saver.v5.history.delta;
+
+import com.odysseusinc.athena.service.saver.SaverV5Delta;
+import com.odysseusinc.athena.service.saver.v5.history.HistorySaver;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ConceptMetadataDeltaSaver extends HistorySaver implements SaverV5Delta {
+
+    @Override
+    public String fileName() {
+
+        return "CONCEPT_METADATA.csv";
+    }
+
+    @Override
+    protected String query() {
+
+        return "SELECT * FROM get_concept_metadata_delta(:version, :versionDelta, :vocabularyArr, TRUE)";
+    }
+}

--- a/src/main/java/com/odysseusinc/athena/service/saver/v5/history/delta/ConceptRelationshipMetadataDeltaSaver.java
+++ b/src/main/java/com/odysseusinc/athena/service/saver/v5/history/delta/ConceptRelationshipMetadataDeltaSaver.java
@@ -1,0 +1,41 @@
+/*
+ *
+ * Copyright 2026 Odysseus Data Services, Inc. (EPAM Systems company)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Company: Odysseus Data Services, Inc.
+ * Created: August 14, 2026
+ *
+ */
+
+package com.odysseusinc.athena.service.saver.v5.history.delta;
+
+import com.odysseusinc.athena.service.saver.SaverV5Delta;
+import com.odysseusinc.athena.service.saver.v5.history.HistorySaver;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ConceptRelationshipMetadataDeltaSaver extends HistorySaver implements SaverV5Delta {
+
+    @Override
+    public String fileName() {
+
+        return "CONCEPT_RELATIONSHIP_METADATA.csv";
+    }
+
+    @Override
+    protected String query() {
+
+        return "SELECT * FROM get_concept_relationship_metadata_delta(:version, :versionDelta, :vocabularyArr, TRUE)";
+    }
+}

--- a/src/main/java/com/odysseusinc/athena/service/saver/v5/history/delta/PackContentDeltaSaver.java
+++ b/src/main/java/com/odysseusinc/athena/service/saver/v5/history/delta/PackContentDeltaSaver.java
@@ -1,0 +1,41 @@
+/*
+ *
+ * Copyright 2026 Odysseus Data Services, Inc. (EPAM Systems company)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Company: Odysseus Data Services, Inc.
+ * Created: August 14, 2026
+ *
+ */
+
+package com.odysseusinc.athena.service.saver.v5.history.delta;
+
+import com.odysseusinc.athena.service.saver.SaverV5Delta;
+import com.odysseusinc.athena.service.saver.v5.history.HistorySaver;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PackContentDeltaSaver extends HistorySaver implements SaverV5Delta {
+
+    @Override
+    public String fileName() {
+
+        return "PACK_CONTENT.csv";
+    }
+
+    @Override
+    protected String query() {
+
+        return "SELECT * FROM get_pack_content_delta(:version, :versionDelta, :vocabularyArr, TRUE)";
+    }
+}

--- a/src/main/java/com/odysseusinc/athena/service/saver/v5/history/version/ConceptMetadataVersionSaver.java
+++ b/src/main/java/com/odysseusinc/athena/service/saver/v5/history/version/ConceptMetadataVersionSaver.java
@@ -1,0 +1,47 @@
+/*
+ *
+ * Copyright 2026 Odysseus Data Services, Inc. (EPAM Systems company)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Company: Odysseus Data Services, Inc.
+ * Created: August 14, 2026
+ *
+ */
+
+package com.odysseusinc.athena.service.saver.v5.history.version;
+
+import com.odysseusinc.athena.service.saver.SaverV5History;
+import com.odysseusinc.athena.service.saver.v5.history.HistorySaver;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ConceptMetadataVersionSaver extends HistorySaver implements SaverV5History {
+
+    @Override
+    public String fileName() {
+
+        return "CONCEPT_METADATA.csv";
+    }
+
+    @Override
+    protected String query() {
+
+        return "SELECT " +
+                "  concept_id, " +
+                "  concept_category, " +
+                "  reuse_status " +
+                "FROM concept_metadata_history " +
+                "WHERE vocabulary_history_id = ANY (get_vocabulary_history_ids(:vocabularyArr, :version)) " +
+                "  AND version = :version";
+    }
+}

--- a/src/main/java/com/odysseusinc/athena/service/saver/v5/history/version/ConceptRelationshipMetadataVersionSaver.java
+++ b/src/main/java/com/odysseusinc/athena/service/saver/v5/history/version/ConceptRelationshipMetadataVersionSaver.java
@@ -1,0 +1,60 @@
+/*
+ *
+ * Copyright 2026 Odysseus Data Services, Inc. (EPAM Systems company)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Company: Odysseus Data Services, Inc.
+ * Created: August 14, 2026
+ *
+ */
+
+package com.odysseusinc.athena.service.saver.v5.history.version;
+
+import com.odysseusinc.athena.service.saver.SaverV5History;
+import com.odysseusinc.athena.service.saver.v5.history.HistorySaver;
+import org.springframework.stereotype.Service;
+
+/**
+ * Unlike {@code ConceptRelationshipVersionSaver} there is no reverse half to union in:
+ * the source table holds one row per relationship it annotates, whichever direction that
+ * relationship was recorded in, and the history table stores it as it stands.
+ */
+@Service
+public class ConceptRelationshipMetadataVersionSaver extends HistorySaver implements SaverV5History {
+
+    @Override
+    public String fileName() {
+
+        return "CONCEPT_RELATIONSHIP_METADATA.csv";
+    }
+
+    @Override
+    protected String query() {
+
+        return "SELECT " +
+                "  concept_id_1, " +
+                "  concept_id_2, " +
+                "  relationship_id, " +
+                "  relationship_predicate_id, " +
+                "  relationship_group, " +
+                "  mapping_source, " +
+                "  confidence, " +
+                "  mapping_tool, " +
+                "  mapper, " +
+                "  reviewer " +
+                "FROM concept_relationship_metadata_history " +
+                "WHERE (vocabulary_history_id_1 = ANY (get_vocabulary_history_ids(:vocabularyArr, :version)) " +
+                "  AND vocabulary_history_id_2 = ANY (get_vocabulary_history_ids(:vocabularyArr, :version))) " +
+                "  AND version = :version";
+    }
+}

--- a/src/main/java/com/odysseusinc/athena/service/saver/v5/history/version/PackContentVersionSaver.java
+++ b/src/main/java/com/odysseusinc/athena/service/saver/v5/history/version/PackContentVersionSaver.java
@@ -1,0 +1,48 @@
+/*
+ *
+ * Copyright 2026 Odysseus Data Services, Inc. (EPAM Systems company)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Company: Odysseus Data Services, Inc.
+ * Created: August 14, 2026
+ *
+ */
+
+package com.odysseusinc.athena.service.saver.v5.history.version;
+
+import com.odysseusinc.athena.service.saver.SaverV5History;
+import com.odysseusinc.athena.service.saver.v5.history.HistorySaver;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PackContentVersionSaver extends HistorySaver implements SaverV5History {
+
+    @Override
+    public String fileName() {
+
+        return "PACK_CONTENT.csv";
+    }
+
+    @Override
+    protected String query() {
+
+        return "SELECT " +
+                "  pack_concept_id, " +
+                "  drug_concept_id, " +
+                "  amount, " +
+                "  box_size " +
+                "FROM pack_content_history " +
+                "WHERE vocabulary_history_id = ANY (get_vocabulary_history_ids(:vocabularyArr, :version)) " +
+                "  AND version = :version";
+    }
+}

--- a/src/main/resources/db/migration/v5/V20260814120001__schema-add-cdm55-tables.sql
+++ b/src/main/resources/db/migration/v5/V20260814120001__schema-add-cdm55-tables.sql
@@ -1,0 +1,44 @@
+-- CDM 5.5 adds three vocabulary tables. They are delivered to users in the download
+-- bundle only; nothing in Athena reads them.
+--
+-- The foreign keys and check constraints of the upstream DDL are deliberately not
+-- reproduced here. No table in this schema carries a foreign key: import_tables() drops
+-- every index, truncates and COPYs, which constraints would make order-dependent and
+-- slow. Validity is enforced by the vocabulary release process.
+--
+-- Concept identifiers are BIGINT rather than the INT of the upstream DDL, to match
+-- CONCEPT.CONCEPT_ID and every other reference to it in this schema.
+
+CREATE TABLE CONCEPT_METADATA
+(
+   CONCEPT_ID BIGINT NOT NULL,
+   CONCEPT_CATEGORY VARCHAR(20),
+   REUSE_STATUS VARCHAR(20)
+);
+CREATE INDEX CONCEPT_METADATA_CONCEPTID ON CONCEPT_METADATA (CONCEPT_ID);
+
+CREATE TABLE CONCEPT_RELATIONSHIP_METADATA
+(
+   CONCEPT_ID_1 BIGINT NOT NULL,
+   CONCEPT_ID_2 BIGINT NOT NULL,
+   RELATIONSHIP_ID VARCHAR(20) NOT NULL,
+   RELATIONSHIP_PREDICATE_ID VARCHAR(20),
+   RELATIONSHIP_GROUP INTEGER,
+   MAPPING_SOURCE VARCHAR(50),
+   CONFIDENCE DOUBLE PRECISION,
+   MAPPING_TOOL VARCHAR(50),
+   MAPPER VARCHAR(50),
+   REVIEWER VARCHAR(50)
+);
+CREATE INDEX CONCEPT_RELATIONSHIP_METADATA_C_1 ON CONCEPT_RELATIONSHIP_METADATA (CONCEPT_ID_1);
+CREATE INDEX CONCEPT_RELATIONSHIP_METADATA_C_2 ON CONCEPT_RELATIONSHIP_METADATA (CONCEPT_ID_2);
+
+CREATE TABLE PACK_CONTENT
+(
+   PACK_CONCEPT_ID BIGINT NOT NULL,
+   DRUG_CONCEPT_ID BIGINT NOT NULL,
+   AMOUNT SMALLINT,
+   BOX_SIZE SMALLINT
+);
+CREATE INDEX PACK_CONCEPTID ON PACK_CONTENT (PACK_CONCEPT_ID);
+CREATE INDEX PACK_DRUG_CONCEPTID ON PACK_CONTENT (DRUG_CONCEPT_ID);

--- a/src/main/resources/db/migration/v5/V20260814120002__schema-import-cdm55-tables.sql
+++ b/src/main/resources/db/migration/v5/V20260814120002__schema-import-cdm55-tables.sql
@@ -1,0 +1,126 @@
+-- Teach the vocabulary loader about the three CDM 5.5 tables.
+--
+-- Both functions are reproduced in full because plpgsql has no way to amend one in place.
+-- The only changes against V20170928141101 and V20171221202125 are the three import_table
+-- calls, the six index statements and the three locks.
+--
+-- import_table() derives the source file from the prefix and the table name, so these
+-- load from /home/athena_vocab_loader/v5_concept_metadata.csv and its two siblings.
+
+CREATE OR REPLACE FUNCTION import_tables(
+)
+  RETURNS VOID AS
+$body$
+DECLARE
+  db         VARCHAR := 'athena_cdm_v5';
+  csv_prefix VARCHAR := 'v5_';
+BEGIN
+  RAISE NOTICE '%: import_tables is started: %', db, now();
+
+  DROP INDEX DRUG_CONCEPTID;
+  DROP INDEX INGREDIENT_CONCEPTID;
+  DROP INDEX CONCEPT_RELATIONSHIP_C_1;
+  DROP INDEX CONCEPT_RELATIONSHIP_C_2;
+  DROP INDEX ancestor_conceptid;
+  DROP INDEX descendant_conceptid;
+  DROP INDEX concept_ancestor_desc_concept_level;
+  DROP INDEX concept_vocab;
+  DROP INDEX CONCEPT_METADATA_CONCEPTID;
+  DROP INDEX CONCEPT_RELATIONSHIP_METADATA_C_1;
+  DROP INDEX CONCEPT_RELATIONSHIP_METADATA_C_2;
+  DROP INDEX PACK_CONCEPTID;
+  DROP INDEX PACK_DRUG_CONCEPTID;
+
+  PERFORM import_table(db, csv_prefix, 'concept');
+  PERFORM import_table(db, csv_prefix, 'concept_relationship');
+  PERFORM import_table(db, csv_prefix, 'concept_synonym');
+
+  PERFORM import_table(db, csv_prefix, 'concept_ancestor');
+  PERFORM import_table(db, csv_prefix, 'relationship');
+  PERFORM import_table(db, csv_prefix, 'vocabulary');
+
+  PERFORM import_table(db, csv_prefix, 'concept_class');
+  PERFORM import_table(db, csv_prefix, 'domain');
+  PERFORM import_table(db, csv_prefix, 'drug_strength');
+
+  PERFORM import_table(db, csv_prefix, 'concept_metadata');
+  PERFORM import_table(db, csv_prefix, 'concept_relationship_metadata');
+  PERFORM import_table(db, csv_prefix, 'pack_content');
+
+  RAISE NOTICE 'restore INDEXES';
+  CREATE INDEX DRUG_CONCEPTID
+    ON DRUG_STRENGTH (DRUG_CONCEPT_ID);
+  CREATE INDEX INGREDIENT_CONCEPTID
+    ON DRUG_STRENGTH (INGREDIENT_CONCEPT_ID);
+
+  CREATE INDEX CONCEPT_RELATIONSHIP_C_1
+    ON CONCEPT_RELATIONSHIP (CONCEPT_ID_1);
+  CREATE INDEX CONCEPT_RELATIONSHIP_C_2
+    ON CONCEPT_RELATIONSHIP (CONCEPT_ID_2);
+
+  CREATE INDEX ANCESTOR_CONCEPTID
+    ON CONCEPT_ANCESTOR (ANCESTOR_CONCEPT_ID);
+  CREATE INDEX DESCENDANT_CONCEPTID
+    ON CONCEPT_ANCESTOR (DESCENDANT_CONCEPT_ID);
+  CREATE INDEX concept_ancestor_desc_concept_level
+    ON concept_ancestor (descendant_concept_id, min_levels_of_separation);
+
+  CREATE INDEX CONCEPT_VOCAB
+    ON CONCEPT (VOCABULARY_ID);
+
+  CREATE INDEX CONCEPT_METADATA_CONCEPTID
+    ON CONCEPT_METADATA (CONCEPT_ID);
+
+  CREATE INDEX CONCEPT_RELATIONSHIP_METADATA_C_1
+    ON CONCEPT_RELATIONSHIP_METADATA (CONCEPT_ID_1);
+  CREATE INDEX CONCEPT_RELATIONSHIP_METADATA_C_2
+    ON CONCEPT_RELATIONSHIP_METADATA (CONCEPT_ID_2);
+
+  CREATE INDEX PACK_CONCEPTID
+    ON PACK_CONTENT (PACK_CONCEPT_ID);
+  CREATE INDEX PACK_DRUG_CONCEPTID
+    ON PACK_CONTENT (DRUG_CONCEPT_ID);
+
+END;
+$body$
+LANGUAGE 'plpgsql'
+SECURITY INVOKER
+COST 100;
+
+
+CREATE OR REPLACE FUNCTION safe_import_of_tables(
+)
+  RETURNS VOID AS
+$body$
+DECLARE
+  db         VARCHAR := 'athena_cdm_v5';
+BEGIN
+
+  RAISE NOTICE '%: safe_import_of_tables is started: %', db, now();
+
+  PERFORM cancel_queries_except_current(db);
+
+  RAISE NOTICE '%: lock tables is started', db;
+
+  LOCK TABLE concept IN ACCESS EXCLUSIVE MODE;
+  LOCK TABLE concept_relationship IN ACCESS EXCLUSIVE MODE;
+  LOCK TABLE concept_synonym IN ACCESS EXCLUSIVE MODE;
+  LOCK TABLE concept_ancestor IN ACCESS EXCLUSIVE MODE;
+  LOCK TABLE relationship IN ACCESS EXCLUSIVE MODE;
+  LOCK TABLE vocabulary IN ACCESS EXCLUSIVE MODE;
+  LOCK TABLE concept_class IN ACCESS EXCLUSIVE MODE;
+  LOCK TABLE "domain" IN ACCESS EXCLUSIVE MODE;
+  LOCK TABLE drug_strength IN ACCESS EXCLUSIVE MODE;
+  LOCK TABLE concept_metadata IN ACCESS EXCLUSIVE MODE;
+  LOCK TABLE concept_relationship_metadata IN ACCESS EXCLUSIVE MODE;
+  LOCK TABLE pack_content IN ACCESS EXCLUSIVE MODE;
+
+  PERFORM import_tables();
+
+  REFRESH MATERIALIZED VIEW concepts_view;
+  RAISE NOTICE '%: safe_import_of_tables() is finished', db;
+END;
+$body$
+LANGUAGE 'plpgsql'
+SECURITY INVOKER
+COST 100;

--- a/src/main/resources/db/migration/v5_history/V20260814120001__add-cdm55-history.sql
+++ b/src/main/resources/db/migration/v5_history/V20260814120001__add-cdm55-history.sql
@@ -1,0 +1,275 @@
+-- History tables for the three CDM 5.5 tables, so that a pinned version and a delta can
+-- be served for them the same way they are for drug_strength.
+--
+-- Partitioned by version like every other history table. Each row carries the
+-- vocabulary_history_id of the concept it hangs off, which is what
+-- get_vocabulary_history_ids() filters on when a bundle is generated for a selection of
+-- vocabularies. concept_relationship_metadata carries two, one per side, mirroring
+-- concept_relationship_history.
+
+CREATE TABLE concept_metadata_history
+(
+    concept_id            bigint,
+    concept_category      varchar(20),
+    reuse_status          varchar(20),
+    vocabulary_history_id integer,
+    version               integer
+) PARTITION BY LIST (version);
+
+CREATE TABLE concept_relationship_metadata_history
+(
+    concept_id_1              bigint,
+    concept_id_2              bigint,
+    relationship_id           varchar(20),
+    relationship_predicate_id varchar(20),
+    relationship_group        integer,
+    mapping_source            varchar(50),
+    confidence                double precision,
+    mapping_tool              varchar(50),
+    mapper                    varchar(50),
+    reviewer                  varchar(50),
+    vocabulary_history_id_1   integer,
+    vocabulary_history_id_2   integer,
+    version                   integer
+) PARTITION BY LIST (version);
+
+CREATE TABLE pack_content_history
+(
+    pack_concept_id       bigint,
+    drug_concept_id       bigint,
+    amount                smallint,
+    box_size              smallint,
+    vocabulary_history_id integer,
+    version               integer
+) PARTITION BY LIST (version);
+
+
+-- The three import functions below are reproduced from V20231208120005 with the new
+-- tables added; plpgsql offers no way to amend a function in place.
+
+CREATE OR REPLACE FUNCTION remove_version_from_history(p_version integer, p_schema text)
+    RETURNS void AS
+$$
+DECLARE
+    table_name text;
+    partition_table_name text;
+    vocabulary_tables CONSTANT text[] := ARRAY[
+        'concept_history',
+        'concept_ancestor_history',
+        'concept_class_history',
+        'concept_relationship_history',
+        'concept_synonym_history',
+        'domain_history',
+        'drug_strength_history',
+        'relationship_history',
+        'vocabulary_history',
+        'concept_metadata_history',
+        'concept_relationship_metadata_history',
+        'pack_content_history'
+        ];
+BEGIN
+    FOREACH table_name IN ARRAY vocabulary_tables
+        LOOP
+            partition_table_name := format('%s_%s', table_name, p_version);
+            -- Use IF ELSE  to avoid the message "table does not exist, skipping" during DROP IF EXISTS TABLE
+            IF EXISTS (SELECT 1 FROM information_schema.tables t WHERE t.table_schema = p_schema AND t.table_name = partition_table_name) THEN
+                EXECUTE format('DROP TABLE IF EXISTS %s.%s CASCADE;', p_schema, partition_table_name);
+                RAISE NOTICE '[%] Table %s.%s has been dropped.', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS'), p_schema, partition_table_name;
+            ELSE
+                RAISE NOTICE '[%] Table %s.%s does not exist, skipping.', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS'), p_schema, partition_table_name;
+            END IF;
+        END LOOP;
+    EXECUTE format('DELETE FROM %I.vocabulary_release_version WHERE id = %s', p_schema, p_version);
+
+    RAISE NOTICE '[%] Partitions for version % in schema % have been removed.', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS'), p_version, p_schema;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION create_partitions_for_version(p_version integer, p_schema text)
+    RETURNS void AS
+$$
+DECLARE
+    table_name text;
+    partition_table_name text;
+    vocabulary_tables CONSTANT text[] := ARRAY[
+        'concept_history',
+        'concept_ancestor_history',
+        'concept_class_history',
+        'concept_relationship_history',
+        'concept_synonym_history',
+        'domain_history',
+        'drug_strength_history',
+        'relationship_history',
+        'vocabulary_history',
+        'concept_metadata_history',
+        'concept_relationship_metadata_history',
+        'pack_content_history'
+        ];
+BEGIN
+    FOREACH table_name IN ARRAY vocabulary_tables
+        LOOP
+            partition_table_name := format('%s_%s', table_name, p_version);
+            EXECUTE format('CREATE TABLE %s.%s PARTITION OF %s.%s FOR VALUES IN (%s);', p_schema, partition_table_name, p_schema, table_name, p_version);
+            RAISE NOTICE '[%] Partition %s.%s has been created.', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS'), p_schema, partition_table_name;
+        END LOOP;
+    RAISE NOTICE '[%] Partitions for version % in schema % have been created.', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS'), p_version, p_schema;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION add_version_to_history(p_version integer, p_version_label text, p_target_schema text, p_source_schema text)
+    RETURNS void AS
+$$
+BEGIN
+    RAISE NOTICE '[%] Add new version to the vocabulary_release_version. Version: %, Label: %', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS'), p_version, p_version_label;
+    EXECUTE format(
+            'INSERT INTO %I.vocabulary_release_version (id, vocabulary_name, athena_name, import_datetime) VALUES (%s, %L, %L, clock_timestamp())',
+            p_target_schema,
+            p_version, 'v'||p_version, p_version_label
+            );
+
+    RAISE NOTICE '[%] Concepts...', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS');
+    EXECUTE format('INSERT INTO %I.concept_history_%s
+                SELECT
+                    c.concept_id,
+                    c.concept_name,
+                    c.domain_id,
+                    c.vocabulary_id,
+                    c.vocabulary_history_id,
+                    c.concept_class_id,
+                    c.standard_concept,
+                    c.concept_code,
+                    c.valid_start_date,
+                    c.valid_end_date,
+                    c.invalid_reason,
+                    %s AS version
+                FROM import_concept_temp c',
+                   p_target_schema, p_version,
+                   p_version);
+
+    RAISE NOTICE '[%] Concept Ancestors...', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS');
+    EXECUTE format('INSERT INTO %I.concept_ancestor_history_%s
+                    SELECT ca.*, a.VOCABULARY_HISTORY_ID AS ANCESTOR_VOCABULARY_HISTORY_ID, d.VOCABULARY_HISTORY_ID AS DESCENDANT_HISTORY_VOCABULARY_ID, %s AS version
+                    FROM %I.concept_ancestor AS ca
+                             JOIN import_concept_temp AS a ON ca.ANCESTOR_CONCEPT_ID = a.CONCEPT_ID
+                             JOIN import_concept_temp AS d ON ca.DESCENDANT_CONCEPT_ID = d.CONCEPT_ID;',
+                   p_target_schema, p_version,
+                   p_version,
+                   p_source_schema);
+
+    RAISE NOTICE '[%] Concept Relationships...', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS');
+-- Inserting only half of the concept relationships
+    EXECUTE format('INSERT INTO %I.concept_relationship_history_%s
+                    SELECT
+                        cr.concept_id_1,
+                        cr.concept_id_2,
+                        rl.relationship_id,
+                        rl.reverse_relationship_id,
+                        cr.valid_start_date,
+                        cr2.valid_start_date AS reverse_valid_start_date,
+                        cr.valid_end_date,
+                        cr.invalid_reason,
+                        c1.VOCABULARY_HISTORY_ID AS VOCABULARY_HISTORY_ID_1,
+                        c2.VOCABULARY_HISTORY_ID AS VOCABULARY_HISTORY_ID_2,
+                        %s AS VERSION
+                    FROM %I.concept_relationship AS cr
+                    JOIN %I.relationship AS rl ON cr.relationship_id = rl.relationship_id
+                    JOIN import_concept_temp AS c1 ON cr.CONCEPT_ID_1 = c1.CONCEPT_ID
+                    JOIN import_concept_temp AS c2 ON cr.CONCEPT_ID_2 = c2.CONCEPT_ID
+                    JOIN %I.concept_relationship AS cr2 on cr.CONCEPT_ID_1 = cr2.CONCEPT_ID_2 AND cr.CONCEPT_ID_2 = cr2.CONCEPT_ID_1 AND cr2.relationship_id = reverse_relationship_id
+                    WHERE cr.relationship_id > rl.reverse_relationship_id;',
+                   p_target_schema, p_version,                             --insert params
+                   p_version,                                              --select params
+                   p_source_schema, p_source_schema, p_source_schema);     --from/where params
+
+    RAISE NOTICE '[%] Concept Classes...', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS');
+    EXECUTE format('INSERT INTO %I.concept_class_history_%s
+                    SELECT cc.*, %s AS version
+                    FROM %I.concept_class cc;',
+                   p_target_schema, p_version,
+                   p_version, p_source_schema);
+
+    RAISE NOTICE '[%] Concept Synonyms... ', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS');
+    EXECUTE format('INSERT INTO %I.concept_synonym_history_%s
+                    SELECT cs.*, c.vocabulary_history_id, %s AS version
+                    FROM %I.concept_synonym AS cs
+                    JOIN import_concept_temp AS c ON cs.CONCEPT_ID = c.CONCEPT_ID;',
+                   p_target_schema, p_version,
+                   p_version, p_source_schema);
+
+    RAISE NOTICE '[%] Drug Strength... ', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS');
+    EXECUTE format('INSERT INTO %I.drug_strength_history_%s
+                    SELECT ds.*, c.vocabulary_history_id, %s AS version
+                    FROM %I.drug_strength AS ds
+                    JOIN import_concept_temp AS c ON ds.DRUG_CONCEPT_ID = c.CONCEPT_ID;',
+                   p_target_schema, p_version,
+                   p_version, p_source_schema);
+
+    RAISE NOTICE '[%] Domains...', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS');
+    EXECUTE format('INSERT INTO %I.domain_history_%s
+                    SELECT d.*, %s AS version
+                    FROM %I.domain d;',
+                   p_target_schema, p_version,
+                   p_version, p_source_schema);
+
+    RAISE NOTICE '[%] Relationship History...', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS');
+    EXECUTE format('INSERT INTO %I.relationship_history_%s
+                    SELECT r.*, %s AS version
+                    FROM %I.relationship r;',
+                   p_target_schema, p_version,
+                   p_version, p_source_schema);
+
+    RAISE NOTICE '[%] Vocabulary History...', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS');
+    EXECUTE format('INSERT INTO %I.vocabulary_history_%s
+                    SELECT v.*, %s AS version
+                    FROM import_vocabulary_temp v;',
+                   p_target_schema, p_version,
+                   p_version);
+
+    -- The three below are guarded: a source schema dumped from a release older than
+    -- CDM 5.5 does not have these tables, and importing such a version must still work.
+    -- The partition is created either way, so the version simply carries no rows for
+    -- them and the bundle gets an empty file.
+
+    IF to_regclass(format('%I.%I', p_source_schema, 'concept_metadata')) IS NOT NULL THEN
+        RAISE NOTICE '[%] Concept Metadata... ', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS');
+        EXECUTE format('INSERT INTO %I.concept_metadata_history_%s
+                        SELECT cm.*, c.vocabulary_history_id, %s AS version
+                        FROM %I.concept_metadata AS cm
+                        JOIN import_concept_temp AS c ON cm.CONCEPT_ID = c.CONCEPT_ID;',
+                       p_target_schema, p_version,
+                       p_version, p_source_schema);
+    ELSE
+        RAISE NOTICE '[%] No concept_metadata in %, skipping.', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS'), p_source_schema;
+    END IF;
+
+    IF to_regclass(format('%I.%I', p_source_schema, 'concept_relationship_metadata')) IS NOT NULL THEN
+        RAISE NOTICE '[%] Concept Relationship Metadata... ', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS');
+        EXECUTE format('INSERT INTO %I.concept_relationship_metadata_history_%s
+                        SELECT crm.*,
+                               c1.VOCABULARY_HISTORY_ID AS VOCABULARY_HISTORY_ID_1,
+                               c2.VOCABULARY_HISTORY_ID AS VOCABULARY_HISTORY_ID_2,
+                               %s AS version
+                        FROM %I.concept_relationship_metadata AS crm
+                        JOIN import_concept_temp AS c1 ON crm.CONCEPT_ID_1 = c1.CONCEPT_ID
+                        JOIN import_concept_temp AS c2 ON crm.CONCEPT_ID_2 = c2.CONCEPT_ID;',
+                       p_target_schema, p_version,
+                       p_version, p_source_schema);
+    ELSE
+        RAISE NOTICE '[%] No concept_relationship_metadata in %, skipping.', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS'), p_source_schema;
+    END IF;
+
+    IF to_regclass(format('%I.%I', p_source_schema, 'pack_content')) IS NOT NULL THEN
+        RAISE NOTICE '[%] Pack Content... ', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS');
+        EXECUTE format('INSERT INTO %I.pack_content_history_%s
+                        SELECT pc.*, c.vocabulary_history_id, %s AS version
+                        FROM %I.pack_content AS pc
+                        JOIN import_concept_temp AS c ON pc.PACK_CONCEPT_ID = c.CONCEPT_ID;',
+                       p_target_schema, p_version,
+                       p_version, p_source_schema);
+    ELSE
+        RAISE NOTICE '[%] No pack_content in %, skipping.', TO_CHAR(clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS'), p_source_schema;
+    END IF;
+
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/main/resources/db/migration/v5_history/V20260814120002__add-cdm55-delta.sql
+++ b/src/main/resources/db/migration/v5_history/V20260814120002__add-cdm55-delta.sql
@@ -1,0 +1,184 @@
+-- Delta functions for the three CDM 5.5 tables, built on get_drug_strength_delta
+-- (V20231208120003): a full outer join of the two versions on the table's key, keeping
+-- only rows whose remaining columns differ, and labelling each with I/U/D plus, for the
+-- CSV view, the names of the columns that changed.
+--
+-- No materialized cache is created. Only concept, concept_relationship and
+-- concept_ancestor are cached; everything else is small enough to compute per request,
+-- and these three are smaller still.
+
+CREATE OR REPLACE FUNCTION get_concept_metadata_delta(
+    pVersion1 integer,
+    pVersion2 integer,
+    pVocabularies text[],
+    pCsvView boolean
+)
+    RETURNS TABLE (
+                      row_change_type    text,
+                      attribute_modified text,
+                      concept_id         bigint,
+                      concept_category   varchar(20),
+                      reuse_status       varchar(20)
+                  )
+AS $$
+DECLARE
+    pVocabulariesHistoryV1 integer[];
+    pVocabulariesHistoryV2 integer[];
+BEGIN
+    IF pVersion1 IS NULL OR pVersion2 IS NULL THEN
+        RETURN;
+    END IF;
+    pVocabulariesHistoryV1 := get_vocabulary_history_ids(pVocabularies, pVersion1);
+    pVocabulariesHistoryV2 := get_vocabulary_history_ids(pVocabularies, pVersion2);
+    RETURN QUERY
+        SELECT
+            CASE
+                WHEN cm2.concept_id IS NULL THEN 'I'
+                WHEN cm1.concept_id IS NULL THEN 'D'
+                ELSE 'U'
+                END AS row_change_type,
+            CASE
+                WHEN pCsvView AND cm1.concept_id IS NOT NULL AND cm2.concept_id IS NOT NULL THEN
+                    CONCAT_WS(', ',
+                              CASE WHEN cm1.concept_category IS DISTINCT FROM cm2.concept_category THEN 'concept_category' END,
+                              CASE WHEN cm1.reuse_status IS DISTINCT FROM cm2.reuse_status THEN 'reuse_status' END
+                        )
+                END AS attribute_modified,
+            COALESCE(cm1.concept_id, cm2.concept_id) AS concept_id,
+            cm1.concept_category,
+            cm1.reuse_status
+        FROM
+            (SELECT * FROM concept_metadata_history a1 WHERE a1.version = pVersion1 AND (pVocabularies IS NULL OR a1.vocabulary_history_id = ANY(pVocabulariesHistoryV1))) cm1
+                FULL JOIN
+            (SELECT * FROM concept_metadata_history a2 WHERE a2.version = pVersion2 AND (pVocabularies IS NULL OR a2.vocabulary_history_id = ANY(pVocabulariesHistoryV2))) cm2
+            USING (concept_id)
+        WHERE
+            ROW(cm1.concept_category, cm1.reuse_status) IS DISTINCT FROM
+            ROW(cm2.concept_category, cm2.reuse_status);
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION get_concept_relationship_metadata_delta(
+    pVersion1 integer,
+    pVersion2 integer,
+    pVocabularies text[],
+    pCsvView boolean
+)
+    RETURNS TABLE (
+                      row_change_type           text,
+                      attribute_modified        text,
+                      concept_id_1              bigint,
+                      concept_id_2              bigint,
+                      relationship_id           varchar(20),
+                      relationship_predicate_id varchar(20),
+                      relationship_group        integer,
+                      mapping_source            varchar(50),
+                      confidence                double precision,
+                      mapping_tool              varchar(50),
+                      mapper                    varchar(50),
+                      reviewer                  varchar(50)
+                  )
+AS $$
+DECLARE
+    pVocabulariesHistoryV1 integer[];
+    pVocabulariesHistoryV2 integer[];
+BEGIN
+    IF pVersion1 IS NULL OR pVersion2 IS NULL THEN
+        RETURN;
+    END IF;
+    pVocabulariesHistoryV1 := get_vocabulary_history_ids(pVocabularies, pVersion1);
+    pVocabulariesHistoryV2 := get_vocabulary_history_ids(pVocabularies, pVersion2);
+    RETURN QUERY
+        SELECT
+            CASE
+                WHEN crm2.concept_id_1 IS NULL THEN 'I'
+                WHEN crm1.concept_id_1 IS NULL THEN 'D'
+                ELSE 'U'
+                END AS row_change_type,
+            CASE
+                WHEN pCsvView AND crm1.concept_id_1 IS NOT NULL AND crm2.concept_id_1 IS NOT NULL THEN
+                    CONCAT_WS(', ',
+                              CASE WHEN crm1.relationship_predicate_id IS DISTINCT FROM crm2.relationship_predicate_id THEN 'relationship_predicate_id' END,
+                              CASE WHEN crm1.relationship_group IS DISTINCT FROM crm2.relationship_group THEN 'relationship_group' END,
+                              CASE WHEN crm1.mapping_source IS DISTINCT FROM crm2.mapping_source THEN 'mapping_source' END,
+                              CASE WHEN crm1.confidence IS DISTINCT FROM crm2.confidence THEN 'confidence' END,
+                              CASE WHEN crm1.mapping_tool IS DISTINCT FROM crm2.mapping_tool THEN 'mapping_tool' END,
+                              CASE WHEN crm1.mapper IS DISTINCT FROM crm2.mapper THEN 'mapper' END,
+                              CASE WHEN crm1.reviewer IS DISTINCT FROM crm2.reviewer THEN 'reviewer' END
+                        )
+                END AS attribute_modified,
+            COALESCE(crm1.concept_id_1, crm2.concept_id_1) AS concept_id_1,
+            COALESCE(crm1.concept_id_2, crm2.concept_id_2) AS concept_id_2,
+            COALESCE(crm1.relationship_id, crm2.relationship_id) AS relationship_id,
+            crm1.relationship_predicate_id,
+            crm1.relationship_group,
+            crm1.mapping_source,
+            crm1.confidence,
+            crm1.mapping_tool,
+            crm1.mapper,
+            crm1.reviewer
+        FROM
+            (SELECT * FROM concept_relationship_metadata_history a1 WHERE a1.version = pVersion1 AND (pVocabularies IS NULL OR (a1.vocabulary_history_id_1 = ANY(pVocabulariesHistoryV1) AND a1.vocabulary_history_id_2 = ANY(pVocabulariesHistoryV1)))) crm1
+                FULL JOIN
+            (SELECT * FROM concept_relationship_metadata_history a2 WHERE a2.version = pVersion2 AND (pVocabularies IS NULL OR (a2.vocabulary_history_id_1 = ANY(pVocabulariesHistoryV2) AND a2.vocabulary_history_id_2 = ANY(pVocabulariesHistoryV2)))) crm2
+            USING (concept_id_1, concept_id_2, relationship_id)
+        WHERE
+            ROW(crm1.relationship_predicate_id, crm1.relationship_group, crm1.mapping_source, crm1.confidence, crm1.mapping_tool, crm1.mapper, crm1.reviewer) IS DISTINCT FROM
+            ROW(crm2.relationship_predicate_id, crm2.relationship_group, crm2.mapping_source, crm2.confidence, crm2.mapping_tool, crm2.mapper, crm2.reviewer);
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION get_pack_content_delta(
+    pVersion1 integer,
+    pVersion2 integer,
+    pVocabularies text[],
+    pCsvView boolean
+)
+    RETURNS TABLE (
+                      row_change_type    text,
+                      attribute_modified text,
+                      pack_concept_id    bigint,
+                      drug_concept_id    bigint,
+                      amount             smallint,
+                      box_size           smallint
+                  )
+AS $$
+DECLARE
+    pVocabulariesHistoryV1 integer[];
+    pVocabulariesHistoryV2 integer[];
+BEGIN
+    IF pVersion1 IS NULL OR pVersion2 IS NULL THEN
+        RETURN;
+    END IF;
+    pVocabulariesHistoryV1 := get_vocabulary_history_ids(pVocabularies, pVersion1);
+    pVocabulariesHistoryV2 := get_vocabulary_history_ids(pVocabularies, pVersion2);
+    RETURN QUERY
+        SELECT
+            CASE
+                WHEN pc2.pack_concept_id IS NULL THEN 'I'
+                WHEN pc1.pack_concept_id IS NULL THEN 'D'
+                ELSE 'U'
+                END AS row_change_type,
+            CASE
+                WHEN pCsvView AND pc1.pack_concept_id IS NOT NULL AND pc2.pack_concept_id IS NOT NULL THEN
+                    CONCAT_WS(', ',
+                              CASE WHEN pc1.amount IS DISTINCT FROM pc2.amount THEN 'amount' END,
+                              CASE WHEN pc1.box_size IS DISTINCT FROM pc2.box_size THEN 'box_size' END
+                        )
+                END AS attribute_modified,
+            COALESCE(pc1.pack_concept_id, pc2.pack_concept_id) AS pack_concept_id,
+            COALESCE(pc1.drug_concept_id, pc2.drug_concept_id) AS drug_concept_id,
+            pc1.amount,
+            pc1.box_size
+        FROM
+            (SELECT * FROM pack_content_history a1 WHERE a1.version = pVersion1 AND (pVocabularies IS NULL OR a1.vocabulary_history_id = ANY(pVocabulariesHistoryV1))) pc1
+                FULL JOIN
+            (SELECT * FROM pack_content_history a2 WHERE a2.version = pVersion2 AND (pVocabularies IS NULL OR a2.vocabulary_history_id = ANY(pVocabulariesHistoryV2))) pc2
+            USING (pack_concept_id, drug_concept_id)
+        WHERE
+            ROW(pc1.amount, pc1.box_size) IS DISTINCT FROM
+            ROW(pc2.amount, pc2.box_size);
+END;
+$$ LANGUAGE plpgsql;

--- a/src/main/resources/db/migration/v5_history/V20260814120003__add-cdm55-to-sql-delta.sql
+++ b/src/main/resources/db/migration/v5_history/V20260814120003__add-cdm55-to-sql-delta.sql
@@ -1,0 +1,361 @@
+-- Reproduced from V20240911120001 with the three CDM 5.5 tables added: three CTEs, six
+-- ordering constants and three UNION ALL branches. Everything else is unchanged.
+--
+-- The new statements slot in either side of the delete boundary at 210. Inserts and
+-- updates run at 201-203, after the rows they annotate exist (CONCEPT 160,
+-- CONCEPT_RELATIONSHIP 180); deletes run at 204-206, before those rows are removed
+-- (CONCEPT_RELATIONSHIP_D 220, CONCEPT_D 250). A user whose schema declares the foreign
+-- keys of the upstream DDL can apply the script as it stands.
+
+CREATE OR REPLACE FUNCTION get_sql_statements_delta(
+    pVersion1 INTEGER,
+    pVersion2 INTEGER,
+    pVocabularies TEXT[]
+)
+    RETURNS TABLE (script_text TEXT)
+AS $$
+
+-- Clarification: The following comments provide explanations for the use of placeholders in the context of the function below.
+-- %s: Simple string substitution.
+-- Example: format('This is a simple string: %s', 'Hello')
+-- Output: 'This is a simple string: Hello'
+-- %s is used for simple string values and doesn't perform any quoting or escaping.
+
+-- %I: Identifier substitution (used for identifiers like table or column names).
+-- Example: format('SELECT * FROM %I WHERE column = %s', 'my_table', 'some_value')
+-- Output: 'SELECT * FROM "my_table" WHERE column = some_value'
+-- %I is used to safely include identifiers in SQL statements, ensuring proper quoting to prevent SQL injection.
+
+-- %L: Literal substitution (used for string literals, providing automatic quoting and escaping).
+-- Example: format('This is a literal string: %L', 'Hello, World!')
+-- Output: 'This is a literal string: 'Hello, World!''
+-- %L is used for safely including string literals in SQL statements, automatically handling quoting and escaping.
+DECLARE
+    CPT4_PLACEHOLDER        CONSTANT VARCHAR(255) := '';
+
+    -- Constants for Insert/Update Operations (I/U)
+    CONCEPT_DICT            CONSTANT INTEGER := 110;
+    CONCEPT_CLASS           CONSTANT INTEGER := 120;
+    DOMAIN                  CONSTANT INTEGER := 130;
+    RELATIONSHIP            CONSTANT INTEGER := 140;
+    RELATIONSHIP_U_FOR_I    CONSTANT INTEGER := 145;
+    VOCABULARY              CONSTANT INTEGER := 150;
+    CONCEPT                 CONSTANT INTEGER := 160;
+    CONCEPT_ANCESTOR        CONSTANT INTEGER := 170;
+    CONCEPT_RELATIONSHIP    CONSTANT INTEGER := 180;
+    CONCEPT_SYNONYM         CONSTANT INTEGER := 190;
+    DRUG_STRENGTH           CONSTANT INTEGER := 200;
+    CONCEPT_METADATA               CONSTANT INTEGER := 201;
+    CONCEPT_RELATIONSHIP_METADATA  CONSTANT INTEGER := 202;
+    PACK_CONTENT                   CONSTANT INTEGER := 203;
+
+    -- Constants for Delete Operations (D)
+    CONCEPT_METADATA_D              CONSTANT INTEGER := 204;
+    CONCEPT_RELATIONSHIP_METADATA_D CONSTANT INTEGER := 205;
+    PACK_CONTENT_D                  CONSTANT INTEGER := 206;
+    CONCEPT_ANCESTOR_D      CONSTANT INTEGER := 210;
+    CONCEPT_RELATIONSHIP_D  CONSTANT INTEGER := 220;
+    CONCEPT_SYNONYM_D       CONSTANT INTEGER := 230;
+    DRUG_STRENGTH_D         CONSTANT INTEGER := 240;
+    CONCEPT_D               CONSTANT INTEGER := 250;
+    CONCEPT_CLASS_D         CONSTANT INTEGER := 260;
+    DOMAIN_D                CONSTANT INTEGER := 270;
+    RELATIONSHIP_U_FOR_D    CONSTANT INTEGER := 275;
+    RELATIONSHIP_D          CONSTANT INTEGER := 280;
+    VOCABULARY_D            CONSTANT INTEGER := 290;
+    CONCEPT_DICT_D          CONSTANT INTEGER := 300;
+    CONCEPT_U               CONSTANT INTEGER := 310;
+
+    -- This mock value helps overcome the idx_unique_concept_code constraint in the code. We can set it initially and update with proper values later.
+    MOCK_CODE               CONSTANT VARCHAR= 'OMOP generated';
+BEGIN
+
+    RETURN QUERY
+    WITH ConceptScript AS (
+        SELECT
+            CASE
+                WHEN row_change_type = 'I' THEN FORMAT('INSERT INTO concept (concept_name, domain_id, vocabulary_id, concept_class_id, standard_concept, concept_code, valid_start_date, valid_end_date, invalid_reason, concept_id) VALUES ' ||
+                                                                            '(%L, %L, %L, %L, %L, %L, %L, %L, %L, %s);',
+                                                                                           CASE WHEN vocabulary_id = 'CPT4' THEN CPT4_PLACEHOLDER ELSE concept_name END,
+                                                                                           domain_id, vocabulary_id, concept_class_id, standard_concept, MOCK_CODE,    valid_start_date, valid_end_date, invalid_reason, concept_id)
+                WHEN row_change_type = 'U' THEN FORMAT('UPDATE concept SET  (concept_name, domain_id, vocabulary_id, concept_class_id, standard_concept, concept_code, valid_start_date, valid_end_date, invalid_reason) = ' ||
+                                                                           '(%L, %L, %L, %L, %L, %L, %L, %L, %L) WHERE concept_id=%s;',
+                                                                                           CASE WHEN vocabulary_id = 'CPT4' THEN CPT4_PLACEHOLDER ELSE concept_name END,
+                                                                                           domain_id, vocabulary_id, concept_class_id, standard_concept, MOCK_CODE,     valid_start_date, valid_end_date, invalid_reason, concept_id)
+                WHEN row_change_type = 'D' THEN FORMAT('DELETE FROM concept WHERE concept_id=%s;', concept_id)
+
+                END AS script_text,
+            row_change_type,
+            concept_class_id
+        FROM get_concept_delta_cached(pVersion1, pVersion2, pVocabularies, false)
+        ),
+        ConceptUpdateScript AS (
+            SELECT FORMAT('UPDATE concept SET concept_code = %L WHERE concept_id=%s;', concept_code, concept_id) AS script_text
+            FROM get_concept_delta_cached(pVersion1, pVersion2, pVocabularies, false)
+            WHERE row_change_type IN ('I','U')
+        ),
+         RelationshipScript AS (
+             SELECT
+                 CASE
+                     WHEN row_change_type = 'I' THEN FORMAT ('INSERT INTO relationship (relationship_name, is_hierarchical, defines_ancestry, reverse_relationship_id, relationship_concept_id, relationship_id) VALUES ' ||
+                                                                                      '(%L, %L, %L, %L, %s, %L);',
+                                                                                        relationship_name, is_hierarchical, defines_ancestry, relationship_id,         relationship_concept_id, relationship_id)
+                     WHEN row_change_type = 'U' THEN FORMAT ('UPDATE relationship SET  (relationship_name, is_hierarchical, defines_ancestry, reverse_relationship_id, relationship_concept_id) = ' ||
+                                                                                      '(%L, %L, %L, %L, %s) WHERE relationship_id = %L;',
+                                                                                        relationship_name, is_hierarchical, defines_ancestry, reverse_relationship_id, relationship_concept_id,    relationship_id)
+                     WHEN row_change_type = 'D' THEN FORMAT ('DELETE FROM relationship WHERE relationship_id = %L;', relationship_id)
+                     END AS script_text,
+                 row_change_type
+             FROM get_relationship_delta(pVersion1, pVersion2, pVocabularies, false)
+         ),
+         --We cannot directly set the reverse_relationship_id for a recursive relationship.
+        -- All relationships should be added first. Only after that, the proper reverse_relationship_id can be set.
+         RelationshipUpdateForInsertScript AS (
+             SELECT
+                 FORMAT ('UPDATE relationship SET reverse_relationship_id = %L WHERE relationship_id = %L;', reverse_relationship_id, relationship_id)
+                  script_text
+             FROM get_relationship_delta(pVersion1, pVersion2, pVocabularies, false) r
+             WHERE r.row_change_type = 'I'
+         ),
+
+         RelationshipUpdateForDeleteScript AS (
+             SELECT
+                 FORMAT ('UPDATE relationship SET reverse_relationship_id = %L WHERE relationship_id = %L;', relationship_id, relationship_id)
+                     script_text
+             FROM get_relationship_delta(pVersion1, pVersion2, pVocabularies, false) r
+             WHERE r.row_change_type = 'D'
+         ),
+
+         ConceptAncestorScript AS (
+             SELECT
+                 CASE
+                     WHEN row_change_type = 'I' THEN FORMAT('INSERT INTO concept_ancestor (min_levels_of_separation, max_levels_of_separation,  ancestor_concept_id, descendant_concept_id) VALUES ' ||
+                                                                                         '(%s, %s, %L, %L);',
+                                                                                           min_levels_of_separation, max_levels_of_separation,  ancestor_concept_id, descendant_concept_id)
+                     WHEN row_change_type = 'U' THEN FORMAT('UPDATE concept_ancestor SET  (min_levels_of_separation, max_levels_of_separation) = ' ||
+                                                                                          '(%s, %s) WHERE ancestor_concept_id = %s AND descendant_concept_id = %s;',
+                                                                                           min_levels_of_separation, max_levels_of_separation, ancestor_concept_id, descendant_concept_id)
+                     WHEN row_change_type = 'D' THEN FORMAT('DELETE FROM concept_ancestor WHERE ancestor_concept_id = %s AND descendant_concept_id = %s;', ancestor_concept_id, descendant_concept_id)
+                     END AS script_text,
+                 row_change_type
+             FROM get_concept_ancestor_delta_cached(pVersion1, pVersion2, pVocabularies, false)
+         ),
+         ConceptRelationshipScript AS (
+             SELECT
+                 CASE
+                     WHEN row_change_type = 'I' THEN FORMAT ('INSERT INTO concept_relationship (valid_start_date, valid_end_date, invalid_reason, concept_id_1, concept_id_2, relationship_id) VALUES (%L, %L, %L, %s, %s, %L);',
+                                                                                                valid_start_date, valid_end_date, invalid_reason, concept_id_1, concept_id_2, relationship_id)
+                     WHEN row_change_type = 'U' THEN FORMAT ('UPDATE concept_relationship SET  (valid_start_date, valid_end_date, invalid_reason) = (%L, %L, %L) WHERE concept_id_1 = %s AND concept_id_2 = %s AND relationship_id = %L;',
+                                                                                                valid_start_date, valid_end_date, invalid_reason, concept_id_1, concept_id_2, relationship_id)
+                     WHEN row_change_type = 'D' THEN FORMAT ('DELETE FROM concept_relationship WHERE concept_id_1 = %s AND concept_id_2 = %s AND relationship_id = %L;', concept_id_1, concept_id_2, relationship_id)
+                     END AS script_text,
+                 row_change_type
+             FROM get_concept_relationship_delta_cached(pVersion1, pVersion2, pVocabularies, false)
+         ),
+         ConceptSynonymScript AS (
+             SELECT
+                 CASE
+                     WHEN row_change_type = 'I' THEN FORMAT ('INSERT INTO concept_synonym (concept_synonym_name, language_concept_id, concept_id) VALUES (%L, %s, %s);',
+                                                             concept_synonym_name, language_concept_id, concept_id)
+                     WHEN row_change_type = 'D' THEN FORMAT ('DELETE FROM concept_synonym WHERE concept_id = %s AND concept_synonym_name = %L AND language_concept_id = %L;', concept_id, concept_synonym_name, language_concept_id)
+                     END AS script_text,
+                 row_change_type
+             FROM get_concept_synonym_delta(pVersion1, pVersion2, pVocabularies, false)
+         ),
+         DomainScript AS (
+             SELECT
+                 CASE
+                     WHEN row_change_type = 'I' THEN FORMAT ('INSERT INTO domain (domain_name, domain_concept_id, domain_id) VALUES (%L, %s, %L);',
+                                                             domain_name, domain_concept_id, domain_id)
+                     WHEN row_change_type = 'U' THEN FORMAT ('UPDATE domain SET  (domain_name, domain_concept_id) = (%L, %s) WHERE domain_id = %L;',
+                                                             domain_name, domain_concept_id, domain_id)
+                     WHEN row_change_type = 'D' THEN FORMAT ('DELETE FROM domain WHERE domain_id = %L;', domain_id)
+                     END AS script_text,
+                 row_change_type
+             FROM get_domain_delta(pVersion1, pVersion2, pVocabularies, false)
+         ),
+         DrugStrengthScript AS (
+             SELECT
+                 CASE
+                     WHEN row_change_type = 'I' THEN FORMAT ('INSERT INTO drug_strength (amount_value, amount_unit_concept_id, numerator_value, numerator_unit_concept_id, denominator_value, denominator_unit_concept_id, box_size, valid_start_date, valid_end_date, invalid_reason, drug_concept_id, ingredient_concept_id) VALUES ' ||
+                                                             '(%L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L);',
+                                                             amount_value, amount_unit_concept_id, numerator_value, numerator_unit_concept_id, denominator_value, denominator_unit_concept_id, box_size, valid_start_date, valid_end_date, invalid_reason, drug_concept_id, ingredient_concept_id)
+                     WHEN row_change_type = 'U' THEN FORMAT ('UPDATE drug_strength SET  (amount_value, amount_unit_concept_id, numerator_value, numerator_unit_concept_id, denominator_value, denominator_unit_concept_id, box_size, valid_start_date, valid_end_date, invalid_reason, ingredient_concept_id) = ' ||
+                                                             '(%L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L) WHERE drug_concept_id = %s AND ingredient_concept_id = %s;',
+                                                             amount_value, amount_unit_concept_id, numerator_value, numerator_unit_concept_id, denominator_value, denominator_unit_concept_id, box_size, valid_start_date, valid_end_date, invalid_reason, ingredient_concept_id, drug_concept_id, ingredient_concept_id)
+                     WHEN row_change_type = 'D' THEN
+                         FORMAT ('DELETE FROM drug_strength WHERE drug_concept_id = %s AND ingredient_concept_id = %s;', drug_concept_id, ingredient_concept_id)
+                     END AS script_text,
+                 row_change_type
+             FROM get_drug_strength_delta(pVersion1, pVersion2, pVocabularies, false)
+         ),
+
+         VocabularyScript AS (
+             SELECT
+                 CASE
+                     WHEN row_change_type = 'I' THEN FORMAT ('INSERT INTO vocabulary (vocabulary_name, vocabulary_reference, vocabulary_version, vocabulary_concept_id, vocabulary_id) VALUES (%L, %L, %L, %s, %L);',
+                                                             vocabulary_name, vocabulary_reference, vocabulary_version, vocabulary_concept_id, vocabulary_id)
+                     WHEN row_change_type = 'U' THEN FORMAT ('UPDATE vocabulary SET ( vocabulary_name, vocabulary_reference, vocabulary_version, vocabulary_concept_id) = (%L, %L, %L, %s) WHERE vocabulary_id = %L;',
+                                                             vocabulary_name, vocabulary_reference, vocabulary_version, vocabulary_concept_id, vocabulary_id)
+                     WHEN row_change_type = 'D' THEN FORMAT ('DELETE FROM vocabulary WHERE vocabulary_id = %L;', vocabulary_id)
+                     END AS script_text,
+                 row_change_type
+             FROM get_vocabulary_delta(pVersion1, pVersion2, pVocabularies, false)
+         ),
+         ConceptClassScript AS (
+             SELECT
+                 CASE
+                     WHEN row_change_type = 'I' THEN FORMAT ('INSERT INTO concept_class (concept_class_name, concept_class_concept_id, concept_class_id) VALUES (%L, %s, %L);',
+                                                             concept_class_name, concept_class_concept_id,  concept_class_id)
+                     WHEN row_change_type = 'U' THEN FORMAT ('UPDATE concept_class SET  (concept_class_name, concept_class_concept_id) = (%L, %s) WHERE concept_class_id = %L;',
+                                                             concept_class_name, concept_class_concept_id,  concept_class_id)
+                     WHEN row_change_type = 'D' THEN FORMAT ('DELETE FROM concept_class WHERE concept_class_id = %L;', concept_class_id)
+                     END AS script_text,
+                 row_change_type
+             FROM get_concept_class_delta(pVersion1, pVersion2, pVocabularies, false)
+         ),
+         ConceptMetadataScript AS (
+             SELECT
+                 CASE
+                     WHEN row_change_type = 'I' THEN FORMAT ('INSERT INTO concept_metadata (concept_category, reuse_status, concept_id) VALUES (%L, %L, %s);',
+                                                             concept_category, reuse_status, concept_id)
+                     WHEN row_change_type = 'U' THEN FORMAT ('UPDATE concept_metadata SET  (concept_category, reuse_status) = (%L, %L) WHERE concept_id = %s;',
+                                                             concept_category, reuse_status, concept_id)
+                     WHEN row_change_type = 'D' THEN FORMAT ('DELETE FROM concept_metadata WHERE concept_id = %s;', concept_id)
+                     END AS script_text,
+                 row_change_type
+             FROM get_concept_metadata_delta(pVersion1, pVersion2, pVocabularies, false)
+         ),
+         ConceptRelationshipMetadataScript AS (
+             SELECT
+                 CASE
+                     WHEN row_change_type = 'I' THEN FORMAT ('INSERT INTO concept_relationship_metadata (relationship_predicate_id, relationship_group, mapping_source, confidence, mapping_tool, mapper, reviewer, concept_id_1, concept_id_2, relationship_id) VALUES ' ||
+                                                             '(%L, %L, %L, %L, %L, %L, %L, %s, %s, %L);',
+                                                             relationship_predicate_id, relationship_group, mapping_source, confidence, mapping_tool, mapper, reviewer, concept_id_1, concept_id_2, relationship_id)
+                     WHEN row_change_type = 'U' THEN FORMAT ('UPDATE concept_relationship_metadata SET  (relationship_predicate_id, relationship_group, mapping_source, confidence, mapping_tool, mapper, reviewer) = ' ||
+                                                             '(%L, %L, %L, %L, %L, %L, %L) WHERE concept_id_1 = %s AND concept_id_2 = %s AND relationship_id = %L;',
+                                                             relationship_predicate_id, relationship_group, mapping_source, confidence, mapping_tool, mapper, reviewer, concept_id_1, concept_id_2, relationship_id)
+                     WHEN row_change_type = 'D' THEN FORMAT ('DELETE FROM concept_relationship_metadata WHERE concept_id_1 = %s AND concept_id_2 = %s AND relationship_id = %L;', concept_id_1, concept_id_2, relationship_id)
+                     END AS script_text,
+                 row_change_type
+             FROM get_concept_relationship_metadata_delta(pVersion1, pVersion2, pVocabularies, false)
+         ),
+         PackContentScript AS (
+             SELECT
+                 CASE
+                     WHEN row_change_type = 'I' THEN FORMAT ('INSERT INTO pack_content (amount, box_size, pack_concept_id, drug_concept_id) VALUES (%L, %L, %s, %s);',
+                                                             amount, box_size, pack_concept_id, drug_concept_id)
+                     WHEN row_change_type = 'U' THEN FORMAT ('UPDATE pack_content SET  (amount, box_size) = (%L, %L) WHERE pack_concept_id = %s AND drug_concept_id = %s;',
+                                                             amount, box_size, pack_concept_id, drug_concept_id)
+                     WHEN row_change_type = 'D' THEN FORMAT ('DELETE FROM pack_content WHERE pack_concept_id = %s AND drug_concept_id = %s;', pack_concept_id, drug_concept_id)
+                     END AS script_text,
+                 row_change_type
+             FROM get_pack_content_delta(pVersion1, pVersion2, pVocabularies, false)
+         )
+
+    SELECT sqls.script_text
+        FROM (
+                 SELECT
+                     CASE WHEN cs.row_change_type = 'D' AND cs.concept_class_id IN ('Concept Class', 'Domain', 'Relationship', 'Vocabulary')
+                            THEN CONCEPT_DICT_D
+                          WHEN cs.row_change_type = 'D'
+                            THEN CONCEPT_D
+                          WHEN cs.concept_class_id IN ('Concept Class', 'Domain', 'Relationship', 'Vocabulary')
+                            THEN CONCEPT_DICT
+                            ELSE CONCEPT
+                     END AS script_number, cs.script_text
+                 FROM ConceptScript cs
+                 UNION ALL
+                 SELECT
+                     CASE WHEN ccs.row_change_type = 'D'
+                            THEN CONCEPT_CLASS_D
+                            ELSE CONCEPT_CLASS
+                     END AS script_number, ccs.script_text
+                 FROM ConceptClassScript ccs
+                 UNION ALL
+                 SELECT
+                     CASE WHEN ds.row_change_type = 'D'
+                             THEN DOMAIN_D
+                             ELSE DOMAIN
+                     END AS script_number, ds.script_text
+                 FROM DomainScript ds
+                 UNION ALL
+                 SELECT
+                     CASE WHEN rs.row_change_type = 'D'
+                             THEN RELATIONSHIP_D
+                             ELSE RELATIONSHIP
+                     END AS script_number, rs.script_text
+                 FROM RelationshipScript rs
+                 UNION ALL
+                 SELECT RELATIONSHIP_U_FOR_I
+                     AS script_number, rs.script_text
+                 FROM RelationshipUpdateForInsertScript rs
+                 UNION ALL
+                 SELECT RELATIONSHIP_U_FOR_D
+                     AS script_number, rs.script_text
+                 FROM RelationshipUpdateForDeleteScript rs
+                 UNION ALL
+                 SELECT
+                     CASE WHEN vs.row_change_type = 'D'
+                            THEN VOCABULARY_D
+                            ELSE VOCABULARY
+                     END AS script_number, vs.script_text
+                 FROM VocabularyScript vs
+                 UNION ALL
+                 SELECT
+                     CASE WHEN cas.row_change_type = 'D'
+                            THEN CONCEPT_ANCESTOR_D
+                            ELSE CONCEPT_ANCESTOR
+                     END AS script_number, cas.script_text
+                 FROM ConceptAncestorScript cas
+                 UNION ALL
+                 SELECT
+                     CASE WHEN crs.row_change_type = 'D'
+                            THEN CONCEPT_RELATIONSHIP_D
+                            ELSE CONCEPT_RELATIONSHIP
+                     END AS script_number, crs.script_text
+                 FROM ConceptRelationshipScript crs
+                 UNION ALL
+                 SELECT
+                     CASE WHEN css.row_change_type = 'D'
+                            THEN CONCEPT_SYNONYM_D
+                            ELSE CONCEPT_SYNONYM
+                     END AS script_number, css.script_text
+                 FROM ConceptSynonymScript css
+                 UNION ALL
+                 SELECT
+                     CASE WHEN dss.row_change_type = 'D'
+                            THEN DRUG_STRENGTH_D
+                            ELSE DRUG_STRENGTH
+                     END AS script_number, dss.script_text
+                 FROM DrugStrengthScript dss
+                 UNION ALL
+                 SELECT
+                     CASE WHEN cms.row_change_type = 'D'
+                            THEN CONCEPT_METADATA_D
+                            ELSE CONCEPT_METADATA
+                     END AS script_number, cms.script_text
+                 FROM ConceptMetadataScript cms
+                 UNION ALL
+                 SELECT
+                     CASE WHEN crms.row_change_type = 'D'
+                            THEN CONCEPT_RELATIONSHIP_METADATA_D
+                            ELSE CONCEPT_RELATIONSHIP_METADATA
+                     END AS script_number, crms.script_text
+                 FROM ConceptRelationshipMetadataScript crms
+                 UNION ALL
+                 SELECT
+                     CASE WHEN pcs.row_change_type = 'D'
+                            THEN PACK_CONTENT_D
+                            ELSE PACK_CONTENT
+                     END AS script_number, pcs.script_text
+                 FROM PackContentScript pcs
+                 UNION ALL
+                 SELECT
+                     CONCEPT_U script_number,
+                     cus.script_text
+                 FROM ConceptUpdateScript cus
+             ) as sqls
+        ORDER BY sqls.script_number;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/test/resources/features/vocabulary-bundle-copy.feature
+++ b/src/test/resources/features/vocabulary-bundle-copy.feature
@@ -5,17 +5,20 @@ Feature: Copy of vocabulary download bundle
   Scenario: Copy and generate bundle
     When user generates a bundle for current version
     Then it is a list containing:
-      | name                 | ext | rows |
-      | CONCEPT_ANCESTOR     | csv | 323  |
-      | CONCEPT_RELATIONSHIP | csv | 674  |
-      | CONCEPT_SYNONYM      | csv | 26   |
-      | DRUG_STRENGTH        | csv | 6    |
-      | RELATIONSHIP         | csv | 12   |
-      | VOCABULARY           | csv | 46   |
-      | CONCEPT_CLASS        | csv | 391  |
-      | CONCEPT              | csv | 184  |
-      | CONCEPT_CPT4         | csv | 3    |
-      | DOMAIN               | csv | 48   |
+      | name                          | ext | rows |
+      | CONCEPT_ANCESTOR              | csv | 323  |
+      | CONCEPT_RELATIONSHIP          | csv | 674  |
+      | CONCEPT_SYNONYM               | csv | 26   |
+      | DRUG_STRENGTH                 | csv | 6    |
+      | RELATIONSHIP                  | csv | 12   |
+      | VOCABULARY                    | csv | 46   |
+      | CONCEPT_CLASS                 | csv | 391  |
+      | CONCEPT                       | csv | 184  |
+      | CONCEPT_CPT4                  | csv | 3    |
+      | DOMAIN                        | csv | 48   |
+      | CONCEPT_METADATA              | csv | 6    |
+      | CONCEPT_RELATIONSHIP_METADATA | csv | 5    |
+      | PACK_CONTENT                  | csv | 4    |
     And user inspect "VOCABULARY" file with "vocabulary_id" == "None"
     Then it is a list containing:
       | vocabulary_id | vocabulary_version |
@@ -29,16 +32,19 @@ Feature: Copy of vocabulary download bundle
     When user set new release version: "v5.0 25-MAY-20"
     And user copy "bundleId" bundle with "Bundle-copy" and generate it
     Then it is a list containing:
-      | name                 | ext | rows |
-      | CONCEPT_ANCESTOR     | csv | 323  |
-      | CONCEPT_RELATIONSHIP | csv | 674  |
-      | CONCEPT_SYNONYM      | csv | 26   |
-      | DRUG_STRENGTH        | csv | 6    |
-      | RELATIONSHIP         | csv | 12   |
-      | VOCABULARY           | csv | 46   |
-      | CONCEPT_CLASS        | csv | 391  |
-      | CONCEPT              | csv | 184  |
-      | DOMAIN               | csv | 48   |
+      | name                          | ext | rows |
+      | CONCEPT_ANCESTOR              | csv | 323  |
+      | CONCEPT_RELATIONSHIP          | csv | 674  |
+      | CONCEPT_SYNONYM               | csv | 26   |
+      | DRUG_STRENGTH                 | csv | 6    |
+      | RELATIONSHIP                  | csv | 12   |
+      | VOCABULARY                    | csv | 46   |
+      | CONCEPT_CLASS                 | csv | 391  |
+      | CONCEPT                       | csv | 184  |
+      | DOMAIN                        | csv | 48   |
+      | CONCEPT_METADATA              | csv | 6    |
+      | CONCEPT_RELATIONSHIP_METADATA | csv | 5    |
+      | PACK_CONTENT                  | csv | 4    |
     And user inspect "VOCABULARY" file with "vocabulary_id" == "None"
     Then it is a list containing:
       | vocabulary_id | vocabulary_version |

--- a/src/test/resources/features/vocabulary-bundle-for-current.feature
+++ b/src/test/resources/features/vocabulary-bundle-for-current.feature
@@ -9,25 +9,31 @@ Feature: Generate vocabulary download bundle for current version
 
     When user generates a bundle for current version
     Then it is a list containing:
-      | name                 | ext | rows |
-      | CONCEPT_ANCESTOR     | csv | 323  |
-      | CONCEPT_RELATIONSHIP | csv | 674  |
-      | CONCEPT_SYNONYM      | csv | 26   |
-      | DRUG_STRENGTH        | csv | 6    |
-      | RELATIONSHIP         | csv | 12   |
-      | VOCABULARY           | csv | 46   |
-      | CONCEPT_CLASS        | csv | 391  |
-      | CONCEPT              | csv | 184  |
-      | DOMAIN               | csv | 48   |
+      | name                          | ext | rows |
+      | CONCEPT_ANCESTOR              | csv | 323  |
+      | CONCEPT_RELATIONSHIP          | csv | 674  |
+      | CONCEPT_SYNONYM               | csv | 26   |
+      | DRUG_STRENGTH                 | csv | 6    |
+      | RELATIONSHIP                  | csv | 12   |
+      | VOCABULARY                    | csv | 46   |
+      | CONCEPT_CLASS                 | csv | 391  |
+      | CONCEPT                       | csv | 184  |
+      | DOMAIN                        | csv | 48   |
+      | CONCEPT_METADATA              | csv | 6    |
+      | CONCEPT_RELATIONSHIP_METADATA | csv | 5    |
+      | PACK_CONTENT                  | csv | 4    |
     When user compare with a 20200513 version bundle
     Then it is a list containing:
-      | name                 | diff |
-      | CONCEPT_ANCESTOR     | 0    |
-      | CONCEPT_RELATIONSHIP | 0    |
-      | CONCEPT_SYNONYM      | 0    |
-      | DRUG_STRENGTH        | 0    |
-      | RELATIONSHIP         | 0    |
-      | VOCABULARY           | 0    |
-      | CONCEPT_CLASS        | 0    |
-      | CONCEPT              | 0    |
-      | DOMAIN               | 0    |
+      | name                          | diff |
+      | CONCEPT_ANCESTOR              | 0    |
+      | CONCEPT_RELATIONSHIP          | 0    |
+      | CONCEPT_SYNONYM               | 0    |
+      | DRUG_STRENGTH                 | 0    |
+      | RELATIONSHIP                  | 0    |
+      | VOCABULARY                    | 0    |
+      | CONCEPT_CLASS                 | 0    |
+      | CONCEPT                       | 0    |
+      | DOMAIN                        | 0    |
+      | CONCEPT_METADATA              | 0    |
+      | CONCEPT_RELATIONSHIP_METADATA | 0    |
+      | PACK_CONTENT                  | 0    |

--- a/src/test/resources/features/vocabulary-bundle-for-delta.feature
+++ b/src/test/resources/features/vocabulary-bundle-for-delta.feature
@@ -20,47 +20,56 @@ Feature: Generate delta vocabulary download bundle between two version
 
     When user generates delta bundle for versions: 20200515 and 20200509
     Then it is a list of:
-      | name                 | ext | rows  | path            |
-      | CONCEPT_ANCESTOR     | csv | 161   | ~(.+)           |
-      | CONCEPT_CLASS        | csv | 4     | ~(.+)           |
-      | CONCEPT              | csv | 4     | ~(.+)           |
-      | CONCEPT_CPT4         | csv | 2     | ~(.+)           |
-      | CONCEPT_RELATIONSHIP | csv | 24    | ~(.+)           |
-      | CONCEPT_SYNONYM      | csv | 7     | ~(.+)           |
-      | DOMAIN               | csv | 3     | ~(.+)           |
-      | DRUG_STRENGTH        | csv | 3     | ~(.+)           |
-      | RELATIONSHIP         | csv | 6     | ~(.+)           |
-      | delta                | sql | 226   | ~(?<sqlPath>.+) |
-      | VOCABULARY           | csv | 4     | ~(.+)           |
-      | cpt4                 | jar | ~(.+) | ~(.+)           |
-      | readme               | txt | ~(.+) | ~(.+)           |
-      | cpt                  | bat | ~(.+) | ~(.+)           |
-      | cpt                  | sh  | ~(.+) | ~(.+)           |
+      | name                          | ext | rows  | path            |
+      | CONCEPT_ANCESTOR              | csv | 161   | ~(.+)           |
+      | CONCEPT_CLASS                 | csv | 4     | ~(.+)           |
+      | CONCEPT                       | csv | 4     | ~(.+)           |
+      | CONCEPT_CPT4                  | csv | 2     | ~(.+)           |
+      | CONCEPT_RELATIONSHIP          | csv | 24    | ~(.+)           |
+      | CONCEPT_SYNONYM               | csv | 7     | ~(.+)           |
+      | DOMAIN                        | csv | 3     | ~(.+)           |
+      | DRUG_STRENGTH                 | csv | 3     | ~(.+)           |
+      | RELATIONSHIP                  | csv | 6     | ~(.+)           |
+      | delta                         | sql | 237   | ~(?<sqlPath>.+) |
+      | VOCABULARY                    | csv | 4     | ~(.+)           |
+      | CONCEPT_METADATA              | csv | 3     | ~(.+)           |
+      | CONCEPT_RELATIONSHIP_METADATA | csv | 5     | ~(.+)           |
+      | PACK_CONTENT                  | csv | 3     | ~(.+)           |
+      | cpt4                          | jar | ~(.+) | ~(.+)           |
+      | readme                        | txt | ~(.+) | ~(.+)           |
+      | cpt                           | bat | ~(.+) | ~(.+)           |
+      | cpt                           | sh  | ~(.+) | ~(.+)           |
     When user compare and inspect schemas "vocabulary_20200509" and "vocabulary_20200515"
     Then it is a list containing:
-      | name                 | amount1 | amount2 | missing1 | missing2 |
-      | concept              | 186     | 186     | 4        | 4        |
-      | concept_ancestor     | 319     | 319     | 157      | 157      |
-      | concept_class        | 390     | 390     | 3        | 3        |
-      | domain               | 47      | 47      | 2        | 2        |
-      | concept_relationship | 664     | 668     | 14       | 10       |
-      | relationship         | 10      | 10      | 4        | 4        |
-      | concept_synonym      | 25      | 24      | 3        | 4        |
-      | vocabulary           | 103     | 103     | 3        | 3        |
-      | drug_strength        | 5       | 5       | 2        | 2        |
+      | name                          | amount1 | amount2 | missing1 | missing2 |
+      | concept                       | 186     | 186     | 4        | 4        |
+      | concept_ancestor              | 319     | 319     | 157      | 157      |
+      | concept_class                 | 390     | 390     | 3        | 3        |
+      | domain                        | 47      | 47      | 2        | 2        |
+      | concept_relationship          | 664     | 668     | 14       | 10       |
+      | relationship                  | 10      | 10      | 4        | 4        |
+      | concept_synonym               | 25      | 24      | 3        | 4        |
+      | vocabulary                    | 103     | 103     | 3        | 3        |
+      | drug_strength                 | 5       | 5       | 2        | 2        |
+      | concept_metadata              | 5       | 5       | 2        | 2        |
+      | concept_relationship_metadata | 2       | 4       | 4        | 2        |
+      | pack_content                  | 3       | 3       | 2        | 2        |
     When run "sqlPath" script on "vocabulary_20200509" schema
     And user compare and inspect schemas "vocabulary_20200509" and "vocabulary_20200515"
     Then it is a list containing:
-      | name                 | amount1 | amount2 | missing1 | missing2 |
-      | concept              | 186     | 186     | 2        | 2        |
-      | concept_ancestor     | 319     | 319     | 0        | 0        |
-      | concept_class        | 390     | 390     | 0        | 0        |
-      | domain               | 47      | 47      | 0        | 0        |
-      | concept_relationship | 668     | 668     | 0        | 0        |
-      | relationship         | 10      | 10      | 0        | 0        |
-      | concept_synonym      | 24      | 24      | 0        | 0        |
-      | vocabulary           | 103     | 103     | 0        | 0        |
-      | drug_strength        | 5       | 5       | 0        | 0        |
+      | name                          | amount1 | amount2 | missing1 | missing2 |
+      | concept                       | 186     | 186     | 2        | 2        |
+      | concept_ancestor              | 319     | 319     | 0        | 0        |
+      | concept_class                 | 390     | 390     | 0        | 0        |
+      | domain                        | 47      | 47      | 0        | 0        |
+      | concept_relationship          | 668     | 668     | 0        | 0        |
+      | relationship                  | 10      | 10      | 0        | 0        |
+      | concept_synonym               | 24      | 24      | 0        | 0        |
+      | vocabulary                    | 103     | 103     | 0        | 0        |
+      | drug_strength                 | 5       | 5       | 0        | 0        |
+      | concept_metadata              | 5       | 5       | 0        | 0        |
+      | concept_relationship_metadata | 4       | 4       | 0        | 0        |
+      | pack_content                  | 3       | 3       | 0        | 0        |
 
   Scenario: Download delta bundle from cache
     When user inspects list of vocabulary release version
@@ -73,44 +82,53 @@ Feature: Generate delta vocabulary download bundle between two version
 
     When user generates delta bundle for versions: 20200515 and 20200511
     Then it is a list of:
-      | name                 | ext | rows | path            |
-      | CONCEPT_ANCESTOR     | csv | 161  | ~(.+)           |
-      | CONCEPT_CLASS        | csv | 4    | ~(.+)           |
-      | CONCEPT              | csv | 4    | ~(.+)           |
-      | CONCEPT_CPT4         | csv | 2    | ~(.+)           |
-      | CONCEPT_RELATIONSHIP | csv | 24   | ~(.+)           |
-      | CONCEPT_SYNONYM      | csv | 7    | ~(.+)           |
-      | DOMAIN               | csv | 3    | ~(.+)           |
-      | DRUG_STRENGTH        | csv | 3    | ~(.+)           |
-      | RELATIONSHIP         | csv | 6    | ~(.+)           |
-      | delta                | sql | 226  | ~(?<sqlPath>.+) |
-      | VOCABULARY           | csv | 4    | ~(.+)           |
-      | cpt4                 | jar | ~(.+) | ~(.+)           |
-      | readme               | txt | ~(.+) | ~(.+)           |
-      | cpt                  | bat | ~(.+) | ~(.+)           |
-      | cpt                  | sh  | ~(.+) | ~(.+)           |
+      | name                          | ext | rows  | path            |
+      | CONCEPT_ANCESTOR              | csv | 161   | ~(.+)           |
+      | CONCEPT_CLASS                 | csv | 4     | ~(.+)           |
+      | CONCEPT                       | csv | 4     | ~(.+)           |
+      | CONCEPT_CPT4                  | csv | 2     | ~(.+)           |
+      | CONCEPT_RELATIONSHIP          | csv | 24    | ~(.+)           |
+      | CONCEPT_SYNONYM               | csv | 7     | ~(.+)           |
+      | DOMAIN                        | csv | 3     | ~(.+)           |
+      | DRUG_STRENGTH                 | csv | 3     | ~(.+)           |
+      | RELATIONSHIP                  | csv | 6     | ~(.+)           |
+      | delta                         | sql | 237   | ~(?<sqlPath>.+) |
+      | VOCABULARY                    | csv | 4     | ~(.+)           |
+      | CONCEPT_METADATA              | csv | 3     | ~(.+)           |
+      | CONCEPT_RELATIONSHIP_METADATA | csv | 5     | ~(.+)           |
+      | PACK_CONTENT                  | csv | 3     | ~(.+)           |
+      | cpt4                          | jar | ~(.+) | ~(.+)           |
+      | readme                        | txt | ~(.+) | ~(.+)           |
+      | cpt                           | bat | ~(.+) | ~(.+)           |
+      | cpt                           | sh  | ~(.+) | ~(.+)           |
     When user compare and inspect schemas "vocabulary_20200511" and "vocabulary_20200515"
     Then it is a list containing:
-      | name                 | amount1 | amount2 | missing1 | missing2 |
-      | concept              | 186     | 186     | 4        | 4        |
-      | concept_ancestor     | 319     | 319     | 157      | 157      |
-      | concept_class        | 390     | 390     | 3        | 3        |
-      | domain               | 47      | 47      | 2        | 2        |
-      | concept_relationship | 664     | 668     | 14       | 10       |
-      | relationship         | 10      | 10      | 4        | 4        |
-      | concept_synonym      | 25      | 24      | 3        | 4        |
-      | vocabulary           | 103     | 103     | 3        | 3        |
-      | drug_strength        | 5       | 5       | 2        | 2        |
+      | name                          | amount1 | amount2 | missing1 | missing2 |
+      | concept                       | 186     | 186     | 4        | 4        |
+      | concept_ancestor              | 319     | 319     | 157      | 157      |
+      | concept_class                 | 390     | 390     | 3        | 3        |
+      | domain                        | 47      | 47      | 2        | 2        |
+      | concept_relationship          | 664     | 668     | 14       | 10       |
+      | relationship                  | 10      | 10      | 4        | 4        |
+      | concept_synonym               | 25      | 24      | 3        | 4        |
+      | vocabulary                    | 103     | 103     | 3        | 3        |
+      | drug_strength                 | 5       | 5       | 2        | 2        |
+      | concept_metadata              | 5       | 5       | 2        | 2        |
+      | concept_relationship_metadata | 2       | 4       | 4        | 2        |
+      | pack_content                  | 3       | 3       | 2        | 2        |
     When run "sqlPath" script on "vocabulary_20200511" schema
     And user compare and inspect schemas "vocabulary_20200511" and "vocabulary_20200515"
     Then it is a list containing:
-      | name                 | amount1 | amount2 | missing1 | missing2 |
-      | concept              | 186     | 186     | 2        | 2        |
-      | concept_ancestor     | 319     | 319     | 0        | 0        |
-      | concept_class        | 390     | 390     | 0        | 0        |
-      | domain               | 47      | 47      | 0        | 0        |
-      | concept_relationship | 668     | 668     | 0        | 0        |
-      | relationship         | 10      | 10      | 0        | 0        |
-      | concept_synonym      | 24      | 24      | 0        | 0        |
-      | vocabulary           | 103     | 103     | 0        | 0        |
-      | drug_strength        | 5       | 5       | 0        | 0        |
+      | name                          | amount1 | amount2 | missing1 | missing2 |
+      | concept                       | 186     | 186     | 2        | 2        |
+      | concept_ancestor              | 319     | 319     | 0        | 0        |
+      | concept_class                 | 390     | 390     | 0        | 0        |
+      | domain                        | 47      | 47      | 0        | 0        |
+      | concept_relationship          | 668     | 668     | 0        | 0        |
+      | relationship                  | 10      | 10      | 0        | 0        |
+      | concept_synonym               | 24      | 24      | 0        | 0        |
+      | vocabulary                    | 103     | 103     | 0        | 0        |
+      | drug_strength                 | 5       | 5       | 0        | 0        |
+      | concept_metadata              | 5       | 5       | 0        | 0        |
+      | concept_relationship_metadata | 4       | 4       | 0        | 0        |
+      | pack_content                  | 3       | 3       | 0        | 0        |

--- a/src/test/resources/features/vocabulary-bundle-for-version.feature
+++ b/src/test/resources/features/vocabulary-bundle-for-version.feature
@@ -16,41 +16,50 @@ Feature: Generate vocabulary download bundle by version
       | 20200515 |
     When user generates a 20200511 version bundle
     Then it is a list containing:
-      | name                 | ext | rows |
-      | CONCEPT_ANCESTOR     | csv | 319  |
-      | CONCEPT_RELATIONSHIP | csv | 662  |
-      | CONCEPT_SYNONYM      | csv | 25   |
-      | DRUG_STRENGTH        | csv | 5    |
-      | RELATIONSHIP         | csv | 10   |
-      | VOCABULARY           | csv | 45   |
-      | CONCEPT_CLASS        | csv | 390  |
-      | CONCEPT              | csv | 183  |
-      | CONCEPT_CPT4         | csv | 2    |
-      | DOMAIN               | csv | 47   |
+      | name                          | ext | rows |
+      | CONCEPT_ANCESTOR              | csv | 319  |
+      | CONCEPT_RELATIONSHIP          | csv | 662  |
+      | CONCEPT_SYNONYM               | csv | 25   |
+      | DRUG_STRENGTH                 | csv | 5    |
+      | RELATIONSHIP                  | csv | 10   |
+      | VOCABULARY                    | csv | 45   |
+      | CONCEPT_CLASS                 | csv | 390  |
+      | CONCEPT                       | csv | 183  |
+      | CONCEPT_CPT4                  | csv | 2    |
+      | DOMAIN                        | csv | 47   |
+      | CONCEPT_METADATA              | csv | 5    |
+      | CONCEPT_RELATIONSHIP_METADATA | csv | 2    |
+      | PACK_CONTENT                  | csv | 3    |
 
     When user generates a 20200513 version bundle
     Then it is a list containing:
-      | name                 | ext | rows |
-      | CONCEPT_ANCESTOR     | csv | 323  |
-      | CONCEPT_RELATIONSHIP | csv | 674  |
-      | CONCEPT_SYNONYM      | csv | 26   |
-      | DRUG_STRENGTH        | csv | 6    |
-      | RELATIONSHIP         | csv | 12   |
-      | VOCABULARY           | csv | 46   |
-      | CONCEPT_CLASS        | csv | 391  |
-      | CONCEPT              | csv | 184  |
-      | CONCEPT_CPT4         | csv | 3    |
-      | DOMAIN               | csv | 48   |
+      | name                          | ext | rows |
+      | CONCEPT_ANCESTOR              | csv | 323  |
+      | CONCEPT_RELATIONSHIP          | csv | 674  |
+      | CONCEPT_SYNONYM               | csv | 26   |
+      | DRUG_STRENGTH                 | csv | 6    |
+      | RELATIONSHIP                  | csv | 12   |
+      | VOCABULARY                    | csv | 46   |
+      | CONCEPT_CLASS                 | csv | 391  |
+      | CONCEPT                       | csv | 184  |
+      | CONCEPT_CPT4                  | csv | 3    |
+      | DOMAIN                        | csv | 48   |
+      | CONCEPT_METADATA              | csv | 6    |
+      | CONCEPT_RELATIONSHIP_METADATA | csv | 5    |
+      | PACK_CONTENT                  | csv | 4    |
 
     When user generates a 20200515 version bundle
     Then it is a list containing:
-      | name                 | ext | rows |
-      | CONCEPT_ANCESTOR     | csv | 319  |
-      | CONCEPT_RELATIONSHIP | csv | 666  |
-      | CONCEPT_SYNONYM      | csv | 24   |
-      | DRUG_STRENGTH        | csv | 5    |
-      | RELATIONSHIP         | csv | 10   |
-      | VOCABULARY           | csv | 45   |
-      | CONCEPT_CLASS        | csv | 390  |
-      | CONCEPT              | csv | 183  |
-      | DOMAIN               | csv | 47   |
+      | name                          | ext | rows |
+      | CONCEPT_ANCESTOR              | csv | 319  |
+      | CONCEPT_RELATIONSHIP          | csv | 666  |
+      | CONCEPT_SYNONYM               | csv | 24   |
+      | DRUG_STRENGTH                 | csv | 5    |
+      | RELATIONSHIP                  | csv | 10   |
+      | VOCABULARY                    | csv | 45   |
+      | CONCEPT_CLASS                 | csv | 390  |
+      | CONCEPT                       | csv | 183  |
+      | DOMAIN                        | csv | 47   |
+      | CONCEPT_METADATA              | csv | 5    |
+      | CONCEPT_RELATIONSHIP_METADATA | csv | 4    |
+      | PACK_CONTENT                  | csv | 3    |

--- a/src/test/resources/testdata/db/migration/v5/V20500101010002__populatetestdata_schema_with_data.sql
+++ b/src/test/resources/testdata/db/migration/v5/V20500101010002__populatetestdata_schema_with_data.sql
@@ -1726,3 +1726,43 @@ Proc context of	Procedure context of (SNOMED)	0	0	Has proc context	44818959
 Contained in	Is contained in (RxNorm)	1	1	Contains	44818959
 Contains	Contains (RxNorm)	1	0	Contained in	44818959
 \.
+
+--
+-- Data for Name: concept_metadata; Type: TABLE DATA; Schema: public; Owner: ohdsi
+--
+-- Same rows as the vocabulary_testdata fixture in the v5_history migrations, so the
+-- current-release bundle and the bundle for the equivalent historical version agree.
+--
+
+INSERT INTO concept_metadata (concept_id, concept_category, reuse_status) VALUES
+    (200962, 'SC', 'R'),
+    (4082919, 'SA', 'RP'),
+    (4116087, 'SC', 'RF'),
+    (4161028, 'A', 'R'),
+    (40488897, 'M', 'RP'),
+    (40488901, 'V', 'RF');
+
+
+--
+-- Data for Name: concept_relationship_metadata; Type: TABLE DATA; Schema: public; Owner: ohdsi
+--
+
+INSERT INTO concept_relationship_metadata
+    (concept_id_1, concept_id_2, relationship_id, relationship_predicate_id, relationship_group,
+     mapping_source, confidence, mapping_tool, mapper, reviewer) VALUES
+    (4116087, 4161028, 'Subsumes', 'broadMatch', 1, 'OMOP', 0.9, 'Usagi', 'mapper1', 'reviewer1'),
+    (4161028, 4116087, 'Is a', 'narrowMatch', 1, 'OMOP', 0.8, 'Usagi', 'mapper1', 'reviewer1'),
+    (4082919, 4161028, 'Is a', 'exactMatch', 2, 'SNOMED', 0.95, 'Usagi', 'mapper2', 'reviewer2'),
+    (40488901, 40486666, 'Is a', 'exactMatch', 1, 'SNOMED', 1, 'Usagi', 'mapper2', 'reviewer2'),
+    (200962, 44500494, 'Subsumes', 'broadMatch', 3, 'OMOP', 0.75, 'Usagi', 'mapper3', 'reviewer3');
+
+
+--
+-- Data for Name: pack_content; Type: TABLE DATA; Schema: public; Owner: ohdsi
+--
+
+INSERT INTO pack_content (pack_concept_id, drug_concept_id, amount, box_size) VALUES
+    (45547509, 45910570, 2, 10),
+    (45930504, 45955133, 1, 5),
+    (4161028, 4116087, 3, NULL),
+    (40488901, 40488897, 4, 20);

--- a/src/test/resources/testdata/db/migration/v5_history/V20500101010001__create_testdata_schema.sql
+++ b/src/test/resources/testdata/db/migration/v5_history/V20500101010001__create_testdata_schema.sql
@@ -156,3 +156,44 @@ CREATE TABLE vocabulary_testdata.vocabulary (
     vocabulary_version character varying(255),
     vocabulary_concept_id integer NOT NULL
 );
+
+
+--
+-- Name: concept_metadata; Type: TABLE; Schema: vocabulary_testdata; Owner: ohdsi
+--
+
+CREATE TABLE vocabulary_testdata.concept_metadata (
+    concept_id integer NOT NULL,
+    concept_category character varying(20),
+    reuse_status character varying(20)
+);
+
+
+--
+-- Name: concept_relationship_metadata; Type: TABLE; Schema: vocabulary_testdata; Owner: ohdsi
+--
+
+CREATE TABLE vocabulary_testdata.concept_relationship_metadata (
+    concept_id_1 integer NOT NULL,
+    concept_id_2 integer NOT NULL,
+    relationship_id character varying(20) NOT NULL,
+    relationship_predicate_id character varying(20),
+    relationship_group integer,
+    mapping_source character varying(50),
+    confidence double precision,
+    mapping_tool character varying(50),
+    mapper character varying(50),
+    reviewer character varying(50)
+);
+
+
+--
+-- Name: pack_content; Type: TABLE; Schema: vocabulary_testdata; Owner: ohdsi
+--
+
+CREATE TABLE vocabulary_testdata.pack_content (
+    pack_concept_id integer NOT NULL,
+    drug_concept_id integer NOT NULL,
+    amount smallint,
+    box_size smallint
+);

--- a/src/test/resources/testdata/db/migration/v5_history/V20500101010002__populatetestdata_schema_with_data.sql
+++ b/src/test/resources/testdata/db/migration/v5_history/V20500101010002__populatetestdata_schema_with_data.sql
@@ -1838,3 +1838,45 @@ Visit	OMOP Visit	OMOP generated	\N	44819119
 Visit Type	OMOP Visit Type	OMOP generated	\N	44819150
 Vocabulary	OMOP Vocabulary	OMOP generated	\N	44819232
 \.
+
+--
+-- Data for Name: concept_metadata; Type: TABLE DATA; Schema: vocabulary_testdata; Owner: ohdsi
+--
+-- The three CDM 5.5 tables below are hand-written rather than dumped, so they are
+-- inserted rather than COPYed. Every concept referenced is one that already exists above,
+-- and 4161028 / 40488901 are the two concepts the version schemas delete, so the delta
+-- scenarios see these rows appear and disappear along with them.
+--
+
+INSERT INTO vocabulary_testdata.concept_metadata (concept_id, concept_category, reuse_status) VALUES
+    (200962, 'SC', 'R'),
+    (4082919, 'SA', 'RP'),
+    (4116087, 'SC', 'RF'),
+    (4161028, 'A', 'R'),
+    (40488897, 'M', 'RP'),
+    (40488901, 'V', 'RF');
+
+
+--
+-- Data for Name: concept_relationship_metadata; Type: TABLE DATA; Schema: vocabulary_testdata; Owner: ohdsi
+--
+
+INSERT INTO vocabulary_testdata.concept_relationship_metadata
+    (concept_id_1, concept_id_2, relationship_id, relationship_predicate_id, relationship_group,
+     mapping_source, confidence, mapping_tool, mapper, reviewer) VALUES
+    (4116087, 4161028, 'Subsumes', 'broadMatch', 1, 'OMOP', 0.9, 'Usagi', 'mapper1', 'reviewer1'),
+    (4161028, 4116087, 'Is a', 'narrowMatch', 1, 'OMOP', 0.8, 'Usagi', 'mapper1', 'reviewer1'),
+    (4082919, 4161028, 'Is a', 'exactMatch', 2, 'SNOMED', 0.95, 'Usagi', 'mapper2', 'reviewer2'),
+    (40488901, 40486666, 'Is a', 'exactMatch', 1, 'SNOMED', 1, 'Usagi', 'mapper2', 'reviewer2'),
+    (200962, 44500494, 'Subsumes', 'broadMatch', 3, 'OMOP', 0.75, 'Usagi', 'mapper3', 'reviewer3');
+
+
+--
+-- Data for Name: pack_content; Type: TABLE DATA; Schema: vocabulary_testdata; Owner: ohdsi
+--
+
+INSERT INTO vocabulary_testdata.pack_content (pack_concept_id, drug_concept_id, amount, box_size) VALUES
+    (45547509, 45910570, 2, 10),
+    (45930504, 45955133, 1, 5),
+    (4161028, 4116087, 3, NULL),
+    (40488901, 40488897, 4, 20);

--- a/src/test/resources/testdata/db/migration/v5_history/V20500101010003__create_testdata_schema_constrains.sql
+++ b/src/test/resources/testdata/db/migration/v5_history/V20500101010003__create_testdata_schema_constrains.sql
@@ -329,3 +329,45 @@ ALTER TABLE ONLY vocabulary_testdata.relationship
 -- PostgreSQL database dump complete
 --
 
+
+--
+-- Name: concept_metadata xpk_concept_metadata; Type: CONSTRAINT; Schema: vocabulary_testdata; Owner: ohdsi
+--
+
+ALTER TABLE ONLY vocabulary_testdata.concept_metadata
+    ADD CONSTRAINT xpk_concept_metadata PRIMARY KEY (concept_id);
+
+
+--
+-- Name: concept_relationship_metadata xpk_concept_relationship_metadata; Type: CONSTRAINT; Schema: vocabulary_testdata; Owner: ohdsi
+--
+
+ALTER TABLE ONLY vocabulary_testdata.concept_relationship_metadata
+    ADD CONSTRAINT xpk_concept_relationship_metadata PRIMARY KEY (concept_id_1, concept_id_2, relationship_id);
+
+
+--
+-- Name: pack_content xpk_pack_content; Type: CONSTRAINT; Schema: vocabulary_testdata; Owner: ohdsi
+--
+-- The upstream DDL declares no key for pack_content. The delta joins on this pair, so
+-- the fixture asserts the assumption rather than leaving it implicit.
+--
+
+ALTER TABLE ONLY vocabulary_testdata.pack_content
+    ADD CONSTRAINT xpk_pack_content PRIMARY KEY (pack_concept_id, drug_concept_id);
+
+
+--
+-- Name: concept_metadata fpk_concept_metadata_concept; Type: FK CONSTRAINT; Schema: vocabulary_testdata; Owner: ohdsi
+--
+
+ALTER TABLE ONLY vocabulary_testdata.concept_metadata
+    ADD CONSTRAINT fpk_concept_metadata_concept FOREIGN KEY (concept_id) REFERENCES vocabulary_testdata.concept(concept_id);
+
+
+--
+-- Name: concept_relationship_metadata fpk_concept_relationship_metadata; Type: FK CONSTRAINT; Schema: vocabulary_testdata; Owner: ohdsi
+--
+
+ALTER TABLE ONLY vocabulary_testdata.concept_relationship_metadata
+    ADD CONSTRAINT fpk_concept_relationship_metadata FOREIGN KEY (concept_id_1, concept_id_2, relationship_id) REFERENCES vocabulary_testdata.concept_relationship(concept_id_1, concept_id_2, relationship_id);

--- a/src/test/resources/testdata/db/migration/v5_history/V20500101010004__create_version_schemas.sql
+++ b/src/test/resources/testdata/db/migration/v5_history/V20500101010004__create_version_schemas.sql
@@ -16,6 +16,9 @@ DELETE FROM vocabulary_20200511.concept_synonym WHERE concept_id = 4161028;
 DELETE FROM vocabulary_20200511.concept_relationship WHERE concept_id_1 = 4161028 OR concept_id_2 = 4161028;
 DELETE FROM vocabulary_20200511.concept_ancestor WHERE ancestor_concept_id = 4161028 OR descendant_concept_id = 4161028;
 DELETE FROM vocabulary_20200511.drug_strength WHERE drug_concept_id = 45547509;
+DELETE FROM vocabulary_20200511.concept_relationship_metadata WHERE concept_id_1 = 4161028 OR concept_id_2 = 4161028;
+DELETE FROM vocabulary_20200511.pack_content WHERE pack_concept_id = 4161028 OR drug_concept_id = 4161028;
+DELETE FROM vocabulary_20200511.concept_metadata WHERE concept_id = 4161028;
 DELETE FROM vocabulary_20200511.concept WHERE concept_id = 4161028;
 DELETE FROM vocabulary_20200511.concept WHERE concept_id = 42628634;
 DELETE FROM vocabulary_20200511.concept_class WHERE concept_class_id = 'Blood Pressure Pos';
@@ -32,6 +35,9 @@ DELETE FROM vocabulary_20200515.concept_synonym WHERE concept_id = 40488901;
 DELETE FROM vocabulary_20200515.concept_relationship WHERE concept_id_1 = 40488901 OR concept_id_2 = 40488901;
 DELETE FROM vocabulary_20200515.concept_ancestor WHERE ancestor_concept_id = 40488901 OR descendant_concept_id = 40488901;
 DELETE FROM vocabulary_20200515.drug_strength WHERE drug_concept_id = 45910570;
+DELETE FROM vocabulary_20200515.concept_relationship_metadata WHERE concept_id_1 = 40488901 OR concept_id_2 = 40488901;
+DELETE FROM vocabulary_20200515.pack_content WHERE pack_concept_id = 40488901 OR drug_concept_id = 40488901;
+DELETE FROM vocabulary_20200515.concept_metadata WHERE concept_id = 40488901;
 DELETE FROM vocabulary_20200515.concept WHERE concept_id = 40488901;
 DELETE FROM vocabulary_20200515.concept WHERE concept_id = 2212194;
 DELETE FROM vocabulary_20200515.concept_class WHERE concept_class_id = 'Body Structure';
@@ -52,6 +58,9 @@ UPDATE vocabulary_20200515.drug_strength SET denominator_value = 0.001, box_size
 UPDATE vocabulary_20200515.relationship SET is_hierarchical = '7', defines_ancestry = '7' WHERE relationship_id = 'Contained in';
 UPDATE vocabulary_20200515.relationship SET is_hierarchical = '9', defines_ancestry = '9' WHERE relationship_id = 'Contains';
 UPDATE vocabulary_20200515.vocabulary SET vocabulary_name = 'Updated WHO Anatomic Therapeutic Chemical Classification', vocabulary_reference = 'Updated FDB UK distribution package', vocabulary_version = 'Updated RXNORM 2018-08-12' WHERE vocabulary_id = 'ATC';
+UPDATE vocabulary_20200515.concept_metadata SET reuse_status = 'RP' WHERE concept_id = 200962;
+UPDATE vocabulary_20200515.concept_relationship_metadata SET confidence = 0.5, reviewer = 'Updated Reviewer' WHERE concept_id_1 = 200962 AND concept_id_2 = 44500494 AND relationship_id = 'Subsumes';
+UPDATE vocabulary_20200515.pack_content SET box_size = 12 WHERE pack_concept_id = 45547509 AND drug_concept_id = 45910570;
 
 
 -- vocabulary_20200509


### PR DESCRIPTION
  CDM 5.5 introduces three vocabulary tables. They now ship in the downloaded archive in all three modes: current release, pinned version, and delta (CSV plus statements in
  delta.sql). Search and the UI are untouched; V4 bundles are out of scope.

  ⚠️  Before deploying: v5_concept_metadata.csv, v5_concept_relationship_metadata.csv and v5_pack_content.csv must exist in /home/athena_vocab_loader/. import_tables() is one
  transaction, so a missing file aborts the whole refresh — no data loss, but the vocabulary update won't go through.

  Changes
  - db/migration/v5/ — three tables with indexes; import_tables() and safe_import_of_tables() extended.
  - db/migration/v5_history/ — three partitioned *_history tables, version import extended, three get_*_delta() functions, get_sql_statements_delta extended.
  - 9 savers under service/saver/v5/ — one per table per mode, auto-discovered by AsyncVocabularyService.

  Filters mirror the file each one annotates. No FK/CHECK constraints — no table in that schema has them, and the loader truncates and COPYs.

  Tests — 226 tests, 0 failures. The real check is the delta round-trip: delta.sql applied to the older schema makes it identical to the newer one (missing 0|0 for all three
  tables). import_tables() isn't covered — it reads CSVs from the server, as with the nine existing tables.

  Open questions
  1. Which release process populates these tables, and are the CSV names right?
  2. pack_content has no unique constraint upstream; the delta joins on (pack_concept_id, drug_concept_id) — duplicates would give a cartesian result. Confirm the pair is
  unique.
  3. Pre-5.5 versions give a header-only CSV rather than no file. Is that what consumers expect?
